### PR TITLE
docs: 第4章のファイルアップロード例に antiforgery 設定を追加

### DIFF
--- a/src/content/docs/04-minimal-api/index.md
+++ b/src/content/docs/04-minimal-api/index.md
@@ -256,13 +256,26 @@ app.MapPost("/products", (Product newProd, IProductRepository repo) =>
 **フォームデータ** や **ファイルアップロード** （`IFormFile`）にも対応しており、必要に応じて `[FromForm]` 属性を付与して明示的にフォーム由来であることを指定できます。
 
 ```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddAntiforgery(); // Antiforgery サービスの登録（必須）
+
+var app = builder.Build();
+app.UseAntiforgery(); // Antiforgery トークン検証ミドルウェア（必須）
+
 // フォームデータとファイルアップロードをバインドする例
 app.MapPost("/upload", ([FromForm] string description, IFormFile file, ILogger<Program> logger) =>
 {
     logger.LogInformation("description: {Description}, fileName: {FileName}, fileSize: {FileSize}", description, file.FileName, file.Length);
     return Results.Ok();
 });
+
+app.Run();
 ```
+
+> [!NOTE]
+> ASP.NET Core 8 以降、`IFormFile` や `[FromForm]` をバインドするエンドポイントでは **Antiforgery トークンの検証が必須** です。`AddAntiforgery()` を忘れると `UseAntiforgery()` 時点で起動時に `InvalidOperationException` が、`UseAntiforgery()` を忘れると対象エンドポイントへのリクエストで HTTP 500 が発生します。
+> クッキーを使わない API クライアントからの呼び出しなど、検証を意図的に無効化したい場合はエンドポイントに `.DisableAntiforgery()` を付与します。詳しくは [ASP.NET Core でのクロスサイト リクエスト フォージェリ (CSRF/XSRF) 攻撃の防止 - Microsoft Learn](https://learn.microsoft.com/ja-jp/aspnet/core/security/anti-request-forgery?view=aspnetcore-10.0) を参照してください。
 
 ```mermaid
 flowchart TD

--- a/src/content/docs/04-minimal-api/index.md
+++ b/src/content/docs/04-minimal-api/index.md
@@ -257,6 +257,8 @@ app.MapPost("/products", (Product newProd, IProductRepository repo) =>
 
 ```csharp
 // Program.cs
+using Microsoft.AspNetCore.Mvc; // [FromForm] は暗黙の using に含まれないため明示的に必要
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAntiforgery(); // Antiforgery サービスの登録（必須）
 

--- a/src/content/docs/04-minimal-api/index.md
+++ b/src/content/docs/04-minimal-api/index.md
@@ -274,7 +274,7 @@ app.Run();
 ```
 
 > [!NOTE]
-> ASP.NET Core 8 以降、`IFormFile` や `[FromForm]` をバインドするエンドポイントでは **Antiforgery トークンの検証が必須** です。`AddAntiforgery()` を忘れると `UseAntiforgery()` 時点で起動時に `InvalidOperationException` が、`UseAntiforgery()` を忘れると対象エンドポイントへのリクエストで HTTP 500 が発生します。
+> ASP.NET Core 8 以降、`IFormFile` や `[FromForm]` をバインドするエンドポイントでは **Antiforgery トークンの検証が必須** です。`AddAntiforgery()` を忘れると `UseAntiforgery()` の時点で起動時に `InvalidOperationException` が発生します。また `UseAntiforgery()` を忘れると、対象エンドポイントへのリクエストが HTTP 500 で失敗します。
 > クッキーを使わない API クライアントからの呼び出しなど、検証を意図的に無効化したい場合はエンドポイントに `.DisableAntiforgery()` を付与します。詳しくは [ASP.NET Core でのクロスサイト リクエスト フォージェリ (CSRF/XSRF) 攻撃の防止 - Microsoft Learn](https://learn.microsoft.com/ja-jp/aspnet/core/security/anti-request-forgery?view=aspnetcore-10.0) を参照してください。
 
 ```mermaid


### PR DESCRIPTION
## 問題

第4章のファイルアップロード例（`src/content/docs/04-minimal-api/index.md`）に `AddAntiforgery()` / `UseAntiforgery()` が含まれておらず、読者がそのままコピーしても動作しませんでした（#32）。

## 修正方法

- コード例を `Program.cs` の全体形に補完し、`builder.Services.AddAntiforgery()` と `app.UseAntiforgery()` を追加
- NOTE で設定漏れ時の挙動（起動時 `InvalidOperationException` / リクエスト時 HTTP 500）と、`.DisableAntiforgery()` による意図的な無効化を補足
- 第7章はまだ main にマージされていないため、代わりに Microsoft Learn の antiforgery ドキュメントへリンク（URL の 200 応答を確認済み）

## 結果

- 変更は 1 ファイル / +13 行のみ。コード例がコピー＆ペーストでそのまま動作する形になりました
- ローカル `npm run build` 成功（8 ページ、エラーなし）

fixes #32