### PR TITLE
Omit registry URLs from npm lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
       "integrity": "sha1-ePoDa+GmCBtad6XPWfUMd1K2uiY=",
       "license": "MIT",
       "dependencies": {
@@ -34,7 +33,6 @@
     },
     "node_modules/@astrojs/compiler-binding": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding/-/compiler-binding-0.3.2.tgz",
       "integrity": "sha1-hnDIKUSk2xf8NX8FuKqiQddIfLA=",
       "license": "MIT",
       "engines": {
@@ -54,7 +52,6 @@
     },
     "node_modules/@astrojs/compiler-binding-darwin-arm64": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.2.tgz",
       "integrity": "sha1-5XZWZ4zmpUyg66GiI6fdLehNkUA=",
       "cpu": [
         "arm64"
@@ -70,7 +67,6 @@
     },
     "node_modules/@astrojs/compiler-binding-darwin-x64": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.2.tgz",
       "integrity": "sha1-Aw7sVhaXUjrZa+83RJuo7P94RWw=",
       "cpu": [
         "x64"
@@ -86,7 +82,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.2.tgz",
       "integrity": "sha1-hjWPGxTnHECkFTpCaAF7wCYuhzY=",
       "cpu": [
         "arm64"
@@ -102,7 +97,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.2.tgz",
       "integrity": "sha1-zo83TLzOS2vbOVCgAngxvLGgtG0=",
       "cpu": [
         "arm64"
@@ -118,7 +112,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.2.tgz",
       "integrity": "sha1-Cl/Up6PT3Vj9qv0KpTnyFRqj9Zs=",
       "cpu": [
         "x64"
@@ -134,7 +127,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.2.tgz",
       "integrity": "sha1-yZNQ/tw5GYCHCBwhRRE+arkkvmE=",
       "cpu": [
         "x64"
@@ -150,7 +142,6 @@
     },
     "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.2.tgz",
       "integrity": "sha1-tprquJiw2x6blGK9zIZh6baD8L8=",
       "cpu": [
         "wasm32"
@@ -166,7 +157,6 @@
     },
     "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.2.tgz",
       "integrity": "sha1-sqnC1I8xFWetZUdygCLXZ7o72nw=",
       "cpu": [
         "arm64"
@@ -182,7 +172,6 @@
     },
     "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.2.tgz",
       "integrity": "sha1-JtBeSJeMRIt7qBz38PR+SoXVIaI=",
       "cpu": [
         "x64"
@@ -198,7 +187,6 @@
     },
     "node_modules/@astrojs/compiler-rs": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-rs/-/compiler-rs-0.3.2.tgz",
       "integrity": "sha1-SlZnBYKEX7IdvegWBVjfAL2SbKg=",
       "license": "MIT",
       "dependencies": {
@@ -210,7 +198,6 @@
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.10.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
       "integrity": "sha1-XhWbDiabiBLdsagdZJ1xTdXs6Z4=",
       "license": "MIT",
       "dependencies": {
@@ -226,7 +213,6 @@
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/markdown-remark/-/markdown-remark-7.2.2.tgz",
       "integrity": "sha1-xxhWwH8Y3ie6rxkuZcNSJ1MaQbE=",
       "license": "MIT",
       "dependencies": {
@@ -251,7 +237,6 @@
     },
     "node_modules/@astrojs/markdown-satteri": {
       "version": "0.3.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/markdown-satteri/-/markdown-satteri-0.3.5.tgz",
       "integrity": "sha1-fXMAIQZZLGxqV6rbm8jQARam+6I=",
       "license": "MIT",
       "dependencies": {
@@ -264,7 +249,6 @@
     },
     "node_modules/@astrojs/mdx": {
       "version": "7.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/mdx/-/mdx-7.0.5.tgz",
       "integrity": "sha1-TXSFETD40cbuadMe/7Ye+o3OdTM=",
       "license": "MIT",
       "dependencies": {
@@ -298,7 +282,6 @@
     },
     "node_modules/@astrojs/prism": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/prism/-/prism-4.0.2.tgz",
       "integrity": "sha1-XcByWmHqb+ZlpIR05lyWgHmlH0A=",
       "license": "MIT",
       "dependencies": {
@@ -310,7 +293,6 @@
     },
     "node_modules/@astrojs/sitemap": {
       "version": "3.7.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
       "integrity": "sha1-9u7WLkFP7zNBRrhT18Vv5iaZTPg=",
       "license": "MIT",
       "dependencies": {
@@ -321,7 +303,6 @@
     },
     "node_modules/@astrojs/starlight": {
       "version": "0.41.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/starlight/-/starlight-0.41.7.tgz",
       "integrity": "sha1-1QiukNfaNpYCTFndAyw9ohHT54w=",
       "license": "MIT",
       "dependencies": {
@@ -367,7 +348,6 @@
     },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
       "integrity": "sha1-JOW88gPRrAd0fALj8HEBNycggrg=",
       "license": "MIT",
       "dependencies": {
@@ -382,7 +362,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "license": "MIT",
       "engines": {
@@ -391,7 +370,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "license": "MIT",
       "engines": {
@@ -400,7 +378,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
       "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
       "license": "MIT",
       "dependencies": {
@@ -415,7 +392,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.8.tgz",
       "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
       "license": "MIT",
       "dependencies": {
@@ -428,13 +404,11 @@
     },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha1-yiA1sP7+lWqGdv8Maa9z5gX82B8=",
       "license": "MIT"
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
       "integrity": "sha1-pcWWW56qHQao6pJP2bSrAY9LVnM=",
       "cpu": [
         "arm64"
@@ -447,7 +421,6 @@
     },
     "node_modules/@bruits/satteri-darwin-x64": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
       "integrity": "sha1-O89jnHPIOCin43q7+AGfan65/lg=",
       "cpu": [
         "x64"
@@ -460,7 +433,6 @@
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
       "integrity": "sha1-CF3WnAH5+J9kE9gC0BjjBHFLlXI=",
       "cpu": [
         "arm64"
@@ -473,7 +445,6 @@
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
       "integrity": "sha1-Yts0XlGnqK7CBKDzbzjctb03rp0=",
       "cpu": [
         "arm64"
@@ -486,7 +457,6 @@
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
       "integrity": "sha1-Quq2YdUoEBC48gO+X+r8/TppUgQ=",
       "cpu": [
         "x64"
@@ -499,7 +469,6 @@
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
       "integrity": "sha1-UOdkjpOU+bYsfWQwJO8GppodZFI=",
       "cpu": [
         "x64"
@@ -512,7 +481,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
       "integrity": "sha1-zST/vhZQV35ivtes0hxItMXrrR0=",
       "cpu": [
         "wasm32"
@@ -530,7 +498,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "license": "MIT",
       "optional": true,
@@ -541,7 +508,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "license": "MIT",
       "optional": true,
@@ -551,7 +517,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "license": "MIT",
       "optional": true,
@@ -561,7 +526,6 @@
     },
     "node_modules/@bruits/satteri-win32-arm64-msvc": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
       "integrity": "sha1-DYOFJTX2PFCrkCU/4gnlzlz/6wk=",
       "cpu": [
         "arm64"
@@ -574,7 +538,6 @@
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
       "integrity": "sha1-FUinVztYRp3GM+zDhArqwZSJNxA=",
       "cpu": [
         "x64"
@@ -587,7 +550,6 @@
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@capsizecss/unpack/-/unpack-4.0.1.tgz",
       "integrity": "sha1-X8Xzo3GpOmnXZOgaCbrfAUM4Fzk=",
       "license": "MIT",
       "dependencies": {
@@ -599,13 +561,11 @@
     },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha1-6DoaJwTwxeSedZKyFAMaD0o01+U=",
       "license": "Apache-2.0"
     },
     "node_modules/@clack/core": {
       "version": "1.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@clack/core/-/core-1.4.3.tgz",
       "integrity": "sha1-HoMZdPgR1zNwfsZQ5Y9pDX10xfo=",
       "license": "MIT",
       "dependencies": {
@@ -618,7 +578,6 @@
     },
     "node_modules/@clack/prompts": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@clack/prompts/-/prompts-1.7.0.tgz",
       "integrity": "sha1-LWztNjpgi6I/a5YRIFuDBshbvw0=",
       "license": "MIT",
       "dependencies": {
@@ -633,7 +592,6 @@
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
       "integrity": "sha1-ul0LkXMDwLPTwUxIZc3G3tJawF8=",
       "license": "MIT",
       "engines": {
@@ -642,7 +600,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.3.tgz",
       "integrity": "sha1-XpU0ikLNHgbwuao4DNdAkdqk1SA=",
       "license": "MIT",
       "optional": true,
@@ -654,7 +611,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha1-hCV647BTHrKuwf+iPXBwDaAHupU=",
       "license": "MIT",
       "optional": true,
@@ -664,7 +620,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
       "integrity": "sha1-yb9y/UvluSiu6JSCDo2BTtc5Fuk=",
       "license": "MIT",
       "optional": true,
@@ -675,7 +630,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
       "integrity": "sha1-v24QMDvPLnxoaXX6Uvk37Cco2Lw=",
       "cpu": [
         "ppc64"
@@ -691,7 +645,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
       "integrity": "sha1-LYTs5qTiaE2SvibuE9QnV9gxw4E=",
       "cpu": [
         "arm"
@@ -707,7 +660,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
       "integrity": "sha1-DGJGvI0sTRcqrC2z+xGQ1yvWVQQ=",
       "cpu": [
         "arm64"
@@ -723,7 +675,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
       "integrity": "sha1-/DjU1jWNjcHPU/CfdYn+Q262SAE=",
       "cpu": [
         "x64"
@@ -739,7 +690,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
       "integrity": "sha1-+Dr+6sHX2sAcei/QErPkUaBZH8w=",
       "cpu": [
         "arm64"
@@ -755,7 +705,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
       "integrity": "sha1-UQFHwFWnlViNu+FP1rG4rQovMN4=",
       "cpu": [
         "x64"
@@ -771,7 +720,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
       "integrity": "sha1-CTuSAOzwsRW6Tl4kinSFycX4vV4=",
       "cpu": [
         "arm64"
@@ -787,7 +735,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
       "integrity": "sha1-C+Irbfkl0hPoQeqHEjr134Cw+vc=",
       "cpu": [
         "x64"
@@ -803,7 +750,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
       "integrity": "sha1-vrEq1yuE9y0oSIzBuO6ffrFB11M=",
       "cpu": [
         "arm"
@@ -819,7 +765,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
       "integrity": "sha1-G9vGUc2pupmVxT7ZxxzqplCUdi0=",
       "cpu": [
         "arm64"
@@ -835,7 +780,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
       "integrity": "sha1-uB+dVVKbRcIGpGoTghSxqmh5aWs=",
       "cpu": [
         "ia32"
@@ -851,7 +795,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
       "integrity": "sha1-WYZnJBoEyZt27W75QKxQA4xBn5g=",
       "cpu": [
         "loong64"
@@ -867,7 +810,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
       "integrity": "sha1-HFHrnOqQP1PZe1rzsYQdtw9Vlso=",
       "cpu": [
         "mips64el"
@@ -883,7 +825,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
       "integrity": "sha1-Y91h8XzrMagSJ/QT/qyKcbwsUfI=",
       "cpu": [
         "ppc64"
@@ -899,7 +840,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
       "integrity": "sha1-N2Owj95c8lqx+suOd1Lt/kX7/Cc=",
       "cpu": [
         "riscv64"
@@ -915,7 +855,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
       "integrity": "sha1-GhN/8pOoKQbrMXY4W9fo4OXPt8s=",
       "cpu": [
         "s390x"
@@ -931,7 +870,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
       "integrity": "sha1-Jos2IRwUbKVPj+EsV4qNbviXlIU=",
       "cpu": [
         "x64"
@@ -947,7 +885,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
       "integrity": "sha1-Ilca2VHWK7aszILY0frVyMGsC6E=",
       "cpu": [
         "arm64"
@@ -963,7 +900,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
       "integrity": "sha1-QvzFcpfrCgyj9fxHUpH0waP3wN4=",
       "cpu": [
         "x64"
@@ -979,7 +915,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
       "integrity": "sha1-nrMq8QSsPaz07coB9ZZmSqsMc+8=",
       "cpu": [
         "arm64"
@@ -995,7 +930,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
       "integrity": "sha1-/r7SQC1giCJekfIPtM4lIq0KTv0=",
       "cpu": [
         "x64"
@@ -1011,7 +945,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
       "integrity": "sha1-hWQcPUZkKL+8zqXyHCaDZmP+9c4=",
       "cpu": [
         "arm64"
@@ -1027,7 +960,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
       "integrity": "sha1-pzb52JYkgQRfxMPlT1R58iyHD7Q=",
       "cpu": [
         "x64"
@@ -1043,7 +975,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
       "integrity": "sha1-7lq0D60YYgG2UqM/il6xSenkJTI=",
       "cpu": [
         "arm64"
@@ -1059,7 +990,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
       "integrity": "sha1-xA0optmaEn2mcR8q/XSxHLY7Bqc=",
       "cpu": [
         "ia32"
@@ -1075,7 +1005,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
       "integrity": "sha1-shr/uATMFnwTPZX0WzodwTI7moc=",
       "cpu": [
         "x64"
@@ -1091,7 +1020,6 @@
     },
     "node_modules/@expressive-code/core": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/core/-/core-0.44.1.tgz",
       "integrity": "sha1-f0K9tpME4GoxR6GoA5xwXuSOsvs=",
       "license": "MIT",
       "dependencies": {
@@ -1108,7 +1036,6 @@
     },
     "node_modules/@expressive-code/plugin-frames": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/plugin-frames/-/plugin-frames-0.44.1.tgz",
       "integrity": "sha1-ZBYWl09zUuE1cmQGPIwhHzmyhDk=",
       "license": "MIT",
       "dependencies": {
@@ -1117,7 +1044,6 @@
     },
     "node_modules/@expressive-code/plugin-shiki": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.1.tgz",
       "integrity": "sha1-zsr85/Ob5h0UfLel/VAD+obj54g=",
       "license": "MIT",
       "dependencies": {
@@ -1127,7 +1053,6 @@
     },
     "node_modules/@expressive-code/plugin-text-markers": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.1.tgz",
       "integrity": "sha1-fRMq5v7NKhAu40xR9uP/XUnoOwg=",
       "license": "MIT",
       "dependencies": {
@@ -1136,13 +1061,11 @@
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha1-qw6epoHWyKEhTzDNdB/jogzFf1c=",
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
       "version": "3.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify/utils/-/utils-3.1.4.tgz",
       "integrity": "sha1-BNrQFOjtgLG740H10JAFnqDGBXg=",
       "license": "MIT",
       "dependencies": {
@@ -1153,7 +1076,6 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha1-sMLC+mYa33Xv/WtJZEl82AAQu50=",
       "license": "MIT",
       "engines": {
@@ -1162,7 +1084,6 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
       "integrity": "sha1-iydAiEvFixJ/wwIEeaASlPoQlcs=",
       "cpu": [
         "arm64"
@@ -1184,7 +1105,6 @@
     },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
       "integrity": "sha1-kt+RMg+vV8xUszEYV3DVqT1RAEk=",
       "cpu": [
         "x64"
@@ -1206,7 +1126,6 @@
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha1-SAGME3mo9QfWgdbNjb5D2XldyAk=",
       "license": "Apache-2.0",
       "optional": true,
@@ -1225,7 +1144,6 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
       "integrity": "sha1-IntB/8bJlhK86rpW+ZShkz13lXM=",
       "cpu": [
         "arm64"
@@ -1241,7 +1159,6 @@
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
       "integrity": "sha1-aUkD7EEMAJRc5bDCbayD1xhMi4Y=",
       "cpu": [
         "x64"
@@ -1257,7 +1174,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
       "integrity": "sha1-5g4IjIBr3hrCi+ZItgw0ZfQcGKc=",
       "cpu": [
         "arm"
@@ -1273,7 +1189,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
       "integrity": "sha1-Sd3xVnKGZqId7tBxbzu3K7NRF54=",
       "cpu": [
         "arm64"
@@ -1289,7 +1204,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
       "integrity": "sha1-vjFhqv1llBez4mN037vNLaK/tiw=",
       "cpu": [
         "ppc64"
@@ -1305,7 +1219,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
       "integrity": "sha1-vwCKZ3nZvitWpN9nt1OUH3Z8lX0=",
       "cpu": [
         "riscv64"
@@ -1321,7 +1234,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
       "integrity": "sha1-lYOBS421iInIW62eXgt4JSV/85Q=",
       "cpu": [
         "s390x"
@@ -1337,7 +1249,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
       "integrity": "sha1-q8mjEUSVtwW6ILfBVoue7NYq67s=",
       "cpu": [
         "x64"
@@ -1353,7 +1264,6 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
       "integrity": "sha1-5Y+xSnh58V2ecKmChw84TzmoMqI=",
       "cpu": [
         "arm64"
@@ -1369,7 +1279,6 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
       "integrity": "sha1-VhFID8t0Zd1TFgRNtTrXqEPtSvg=",
       "cpu": [
         "x64"
@@ -1385,7 +1294,6 @@
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
       "integrity": "sha1-yNpQDEAWiTqJ1G6YMtCKBu73fyc=",
       "cpu": [
         "arm"
@@ -1407,7 +1315,6 @@
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
       "integrity": "sha1-RLZYI+zJd9RYWzCAcP/zlHJW3gQ=",
       "cpu": [
         "arm64"
@@ -1429,7 +1336,6 @@
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
       "integrity": "sha1-6h19uBj1KvHh4FfoLVXyOy3jhkw=",
       "cpu": [
         "ppc64"
@@ -1451,7 +1357,6 @@
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
       "integrity": "sha1-civXmUZYeRsC0QN+oJyly3gDDY0=",
       "cpu": [
         "riscv64"
@@ -1473,7 +1378,6 @@
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
       "integrity": "sha1-6ClIF9faSVVBpKhw9W5rXQ+GQ80=",
       "cpu": [
         "s390x"
@@ -1495,7 +1399,6 @@
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
       "integrity": "sha1-mEPDLzmurEtg3WD540FlIKTk3kY=",
       "cpu": [
         "x64"
@@ -1517,7 +1420,6 @@
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
       "integrity": "sha1-nP7k7MPUGrmidOAZ3+e0BihAUQw=",
       "cpu": [
         "arm64"
@@ -1539,7 +1441,6 @@
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
       "integrity": "sha1-IE0GeMjDsVMA2aJuy5wNzaEcpd4=",
       "cpu": [
         "x64"
@@ -1561,7 +1462,6 @@
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha1-QviXm9vhpUGi6bmdO1vgfmtxx8A=",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
@@ -1577,7 +1477,6 @@
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
       "integrity": "sha1-gjqqk9FNuEmZ1bXcln/1bPGWbZ8=",
       "cpu": [
         "wasm32"
@@ -1596,7 +1495,6 @@
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
       "integrity": "sha1-81VNRcviRTKgrepzbsV2WPdKKRE=",
       "cpu": [
         "arm64"
@@ -1615,7 +1513,6 @@
     },
     "node_modules/@img/sharp-win32-ia32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
       "integrity": "sha1-CUKyZDvLV+SEGf5BGd6EB4rgrHQ=",
       "cpu": [
         "ia32"
@@ -1634,7 +1531,6 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
       "integrity": "sha1-iiXKzcdajCYHfAf7pR6AVqrkdPE=",
       "cpu": [
         "x64"
@@ -1653,13 +1549,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "license": "MIT"
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@mdx-js/mdx/-/mdx-3.1.1.tgz",
       "integrity": "sha1-xf/ZkadTaxSeFxde7lehoqURxtE=",
       "license": "MIT",
       "dependencies": {
@@ -1696,7 +1590,6 @@
     },
     "node_modules/@mermaid-js/layout-elk": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@mermaid-js/layout-elk/-/layout-elk-0.2.2.tgz",
       "integrity": "sha1-evTF1T0lrHD4nZa8HexMK4ORoYE=",
       "license": "MIT",
       "dependencies": {
@@ -1709,7 +1602,6 @@
     },
     "node_modules/@mermaid-js/parser": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@mermaid-js/parser/-/parser-1.2.0.tgz",
       "integrity": "sha1-Jm1yjFTS1ANNJw+LMdeQ4mKWpfo=",
       "license": "MIT",
       "dependencies": {
@@ -1718,7 +1610,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
       "integrity": "sha1-xwcGUy5YJ8CTLKa/Q+4sUS8pxjk=",
       "license": "MIT",
       "optional": true,
@@ -1739,13 +1630,11 @@
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha1-VfPZpZdDCgHype9jxrQvdp+c404=",
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.143.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.143.0.tgz",
       "integrity": "sha1-w+TzF4t7VOTdGU6sbUUlimDwCSs=",
       "license": "MIT",
       "funding": {
@@ -1754,7 +1643,6 @@
     },
     "node_modules/@pagefind/darwin-arm64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
       "integrity": "sha1-llFS/8IrzNgpngZffPvGhpob/+A=",
       "cpu": [
         "arm64"
@@ -1767,7 +1655,6 @@
     },
     "node_modules/@pagefind/darwin-x64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
       "integrity": "sha1-tbm0dnPK97KAiRFU4qR1q8SZ+t0=",
       "cpu": [
         "x64"
@@ -1780,13 +1667,11 @@
     },
     "node_modules/@pagefind/default-ui": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/default-ui/-/default-ui-1.5.2.tgz",
       "integrity": "sha1-ZHPNLDSpS4IhxTNKX+8xTNSETDc=",
       "license": "MIT"
     },
     "node_modules/@pagefind/freebsd-x64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
       "integrity": "sha1-z24nnZOMI2hzG7ZVi/j2agyAomk=",
       "cpu": [
         "x64"
@@ -1799,7 +1684,6 @@
     },
     "node_modules/@pagefind/linux-arm64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
       "integrity": "sha1-iyLPwaNMWQM8W9Zmdreobvug9fQ=",
       "cpu": [
         "arm64"
@@ -1812,7 +1696,6 @@
     },
     "node_modules/@pagefind/linux-x64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
       "integrity": "sha1-pzPRwKnZBTEfafiGh3HAzEKQn+Q=",
       "cpu": [
         "x64"
@@ -1825,7 +1708,6 @@
     },
     "node_modules/@pagefind/windows-arm64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
       "integrity": "sha1-bWyzlaVhNqkrkcC9hm9/7DsLvnw=",
       "cpu": [
         "arm64"
@@ -1838,7 +1720,6 @@
     },
     "node_modules/@pagefind/windows-x64": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
       "integrity": "sha1-kx/byfAPcgV5UM0mDvll1P0CqS4=",
       "cpu": [
         "x64"
@@ -1851,7 +1732,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
       "integrity": "sha1-ABuLCwGERwHv2hu2vthLaBxKSIs=",
       "cpu": [
         "arm64"
@@ -1867,7 +1747,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
       "integrity": "sha1-XofGAu1jSm/vCS4hYuJPv7iBxOw=",
       "cpu": [
         "arm64"
@@ -1883,7 +1762,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
       "integrity": "sha1-8y4LKGcUvQOkIdaTQV0F2X0mW3c=",
       "cpu": [
         "x64"
@@ -1899,7 +1777,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
       "integrity": "sha1-XzitV2G2t7IbV6mVZrtSY0xgqxk=",
       "cpu": [
         "x64"
@@ -1915,7 +1792,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
       "integrity": "sha1-q03NB/G9iOjWWa4MO7nS8pCtuJc=",
       "cpu": [
         "arm"
@@ -1931,7 +1807,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
       "integrity": "sha1-0nm3AWA5pyX7ZtgnhLmEH0Lfg9o=",
       "cpu": [
         "arm64"
@@ -1947,7 +1822,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
       "integrity": "sha1-0Iu8k9J0IhRUjFrfffd4iUTlqJo=",
       "cpu": [
         "arm64"
@@ -1963,7 +1837,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
       "integrity": "sha1-ZBjmN0WzGT8mqzu4h0SzpKE1bXw=",
       "cpu": [
         "ppc64"
@@ -1979,7 +1852,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
       "integrity": "sha1-d+ww0HBM9OsctKY/UByYUsZyjPQ=",
       "cpu": [
         "s390x"
@@ -1995,7 +1867,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
       "integrity": "sha1-O5tuDdPobFl/QoWHSMol8d/Vjtg=",
       "cpu": [
         "x64"
@@ -2011,7 +1882,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
       "integrity": "sha1-94AzxZLIvSr0goSkX45LqqC++/U=",
       "cpu": [
         "x64"
@@ -2027,7 +1897,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
       "integrity": "sha1-NulR9ab8qSKlIF4oPQqCufmBmco=",
       "cpu": [
         "arm64"
@@ -2043,7 +1912,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
       "integrity": "sha1-weSUrEfhO9hX/KCzrVnDNYAkH34=",
       "cpu": [
         "arm64"
@@ -2059,7 +1927,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
       "integrity": "sha1-sO///NaHL4oCE3PrQ3kWsbUig6Q=",
       "cpu": [
         "x64"
@@ -2075,13 +1942,11 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/core/-/core-4.4.3.tgz",
       "integrity": "sha1-AKlC+kWtDkFGrG27rDK4twS0Lj8=",
       "license": "MIT",
       "dependencies": {
@@ -2097,7 +1962,6 @@
     },
     "node_modules/@shikijs/engine-javascript": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
       "integrity": "sha1-QtvcGOwvhgA2JGdIOajwkM3Xy2I=",
       "license": "MIT",
       "dependencies": {
@@ -2111,7 +1975,6 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
       "integrity": "sha1-oXVPn0Lg81pVzampd1mQQaKtWwc=",
       "license": "MIT",
       "dependencies": {
@@ -2124,7 +1987,6 @@
     },
     "node_modules/@shikijs/langs": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/langs/-/langs-4.4.3.tgz",
       "integrity": "sha1-ETKCOW8Rnbuo07XoZmglj6jfbns=",
       "license": "MIT",
       "dependencies": {
@@ -2136,7 +1998,6 @@
     },
     "node_modules/@shikijs/primitive": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/primitive/-/primitive-4.4.3.tgz",
       "integrity": "sha1-hkkM6mOz4sVrjZFjBG4BAliETYE=",
       "license": "MIT",
       "dependencies": {
@@ -2150,7 +2011,6 @@
     },
     "node_modules/@shikijs/themes": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/themes/-/themes-4.4.3.tgz",
       "integrity": "sha1-gxCngmH0z3QmY+B+ICjfBGoCvXI=",
       "license": "MIT",
       "dependencies": {
@@ -2162,7 +2022,6 @@
     },
     "node_modules/@shikijs/types": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/types/-/types-4.4.3.tgz",
       "integrity": "sha1-AZr/GfDL+yFkLFn2+EMs7XTie0U=",
       "license": "MIT",
       "dependencies": {
@@ -2175,13 +2034,11 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha1-qQqzHQzB37VMZqaeUVv2JPp7IiQ=",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "license": "MIT",
       "optional": true,
@@ -2191,7 +2048,6 @@
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3/-/d3-7.4.3.tgz",
       "integrity": "sha1-1FUKhdCPSXj68KTDa4SMYeqsB+I=",
       "license": "MIT",
       "dependencies": {
@@ -2229,13 +2085,11 @@
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha1-4CFRRk0C1KG0RkbQ/NuT+viP3ow=",
       "license": "MIT"
     },
     "node_modules/@types/d3-axis": {
       "version": "3.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-axis/-/d3-axis-3.0.6.tgz",
       "integrity": "sha1-52DldluBiLHe+jK8i7YGL4Hkx5U=",
       "license": "MIT",
       "dependencies": {
@@ -2244,7 +2098,6 @@
     },
     "node_modules/@types/d3-brush": {
       "version": "3.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-brush/-/d3-brush-3.0.6.tgz",
       "integrity": "sha1-wvQ2KwRdRy4bGGzb7DKbpSva7mw=",
       "license": "MIT",
       "dependencies": {
@@ -2253,19 +2106,16 @@
     },
     "node_modules/@types/d3-chord": {
       "version": "3.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-chord/-/d3-chord-3.0.6.tgz",
       "integrity": "sha1-FwbKQM9+pZoK3Y9EVu//j4d1eT0=",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha1-NoyWGhjech2oIA6AvzlD+1MTavI=",
       "license": "MIT"
     },
     "node_modules/@types/d3-contour": {
       "version": "3.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-contour/-/d3-contour-3.0.6.tgz",
       "integrity": "sha1-mto/qcTQDjpQk/7QNWx6uSlgQjE=",
       "license": "MIT",
       "dependencies": {
@@ -2275,19 +2125,16 @@
     },
     "node_modules/@types/d3-delaunay": {
       "version": "6.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha1-GFwagMyAf92io/6WD3wRxKJ5UuE=",
       "license": "MIT"
     },
     "node_modules/@types/d3-dispatch": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
       "integrity": "sha1-7wBNihKARs/OQ00XGC+DTkTvlbI=",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-drag/-/d3-drag-3.0.7.tgz",
       "integrity": "sha1-sTq6iyRCtAaMmp5tHYL4vOp3/AI=",
       "license": "MIT",
       "dependencies": {
@@ -2296,19 +2143,16 @@
     },
     "node_modules/@types/d3-dsv": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
       "integrity": "sha1-CjUfmW3Jmzf0+li0ksLRwE49rBc=",
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha1-4o2xv7+mFwdvd3DdHZpI6qO2xRs=",
       "license": "MIT"
     },
     "node_modules/@types/d3-fetch": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
       "integrity": "sha1-wEorTyMYGqN28wrwKD28eztWmYA=",
       "license": "MIT",
       "dependencies": {
@@ -2317,19 +2161,16 @@
     },
     "node_modules/@types/d3-force": {
       "version": "3.0.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-force/-/d3-force-3.0.10.tgz",
       "integrity": "sha1-bcj8bh81cE87BXCQvu63rGdL/xo=",
       "license": "MIT"
     },
     "node_modules/@types/d3-format": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-format/-/d3-format-3.0.4.tgz",
       "integrity": "sha1-seRGVkTds/3zomP+uyQKbNYW3pA=",
       "license": "MIT"
     },
     "node_modules/@types/d3-geo": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-geo/-/d3-geo-3.1.1.tgz",
       "integrity": "sha1-nig68XlgHFSVgWALP+wllBkRMp0=",
       "license": "MIT",
       "dependencies": {
@@ -2338,13 +2179,11 @@
     },
     "node_modules/@types/d3-hierarchy": {
       "version": "3.1.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
       "integrity": "sha1-YCP7Oy1GMiny1oD5rEtHRm9x8Xs=",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha1-QSuQ6EhwKF8v+KhGxutgNE8SpBw=",
       "license": "MIT",
       "dependencies": {
@@ -2353,31 +2192,26 @@
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha1-9jKzgMOsoduo40qgSbzWpK8j34o=",
       "license": "MIT"
     },
     "node_modules/@types/d3-polygon": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
       "integrity": "sha1-365UptNdGedqyVZbyzKo5UaTGJw=",
       "license": "MIT"
     },
     "node_modules/@types/d3-quadtree": {
       "version": "3.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
       "integrity": "sha1-1HQLD+NbHFi2bhSI9OftApUvVw8=",
       "license": "MIT"
     },
     "node_modules/@types/d3-random": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-random/-/d3-random-3.0.4.tgz",
       "integrity": "sha1-a9NoO4My/A8B5wWbdja8XH7eczc=",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha1-V6L3ByQub+Hega17/Myq9gYXmvs=",
       "license": "MIT",
       "dependencies": {
@@ -2386,19 +2220,16 @@
     },
     "node_modules/@types/d3-scale-chromatic": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha1-3G1Pmpg3bxjqULrWw5U38bVGPDk=",
       "license": "MIT"
     },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha1-vXpF/AqMMWemMWdeYbwsorBY1KM=",
       "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha1-0VFsxQh1O+BoUs0GdY47tUoisOM=",
       "license": "MIT",
       "dependencies": {
@@ -2407,25 +2238,21 @@
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha1-hHL+7NY5aRRQ3YAA6zPt1EThMj8=",
       "license": "MIT"
     },
     "node_modules/@types/d3-time-format": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
       "integrity": "sha1-1rwea2p9tpzM+73Uw0twYy2enbI=",
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha1-cLvad9wjqnJ0E+IuIUr6Pw6FL3A=",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
       "version": "3.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-transition/-/d3-transition-3.0.9.tgz",
       "integrity": "sha1-ETa8V+nds8OQ3MybX/O30rjZRwY=",
       "license": "MIT",
       "dependencies": {
@@ -2434,7 +2261,6 @@
     },
     "node_modules/@types/d3-zoom": {
       "version": "3.0.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
       "integrity": "sha1-3Msy0cVrHhxuDxGA2ZSJbwOLxAs=",
       "license": "MIT",
       "dependencies": {
@@ -2444,7 +2270,6 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha1-ItHMnVQtNZPK6nZPl0MGqzYobuc=",
       "license": "MIT",
       "dependencies": {
@@ -2453,13 +2278,11 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
       "integrity": "sha1-hYqI6iDzT+ZREfAFpon6Hr9w3Bg=",
       "license": "MIT",
       "dependencies": {
@@ -2468,13 +2291,11 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha1-jr5T1p762nBERU4zBcGQF9l87So=",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/hast/-/hast-3.0.5.tgz",
       "integrity": "sha1-SAIN5MDmNJL0yp20IGjBCPaLf48=",
       "license": "MIT",
       "dependencies": {
@@ -2483,13 +2304,11 @@
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha1-zYI4LE+QL+2WkaLteexoxYmK9MI=",
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha1-fM9y7dLxqn3TQ34YDGQ3NYWATdY=",
       "license": "MIT",
       "dependencies": {
@@ -2498,19 +2317,16 @@
     },
     "node_modules/@types/mdx": {
       "version": "2.0.14",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mdx/-/mdx-2.0.14.tgz",
       "integrity": "sha1-weVBEyZbFSAhqwr+BDTjyt2Qv+M=",
       "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
       "license": "MIT"
     },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/nlcst/-/nlcst-2.0.3.tgz",
       "integrity": "sha1-McrTRuqrSKmopYRl09BeJTDdp2I=",
       "license": "MIT",
       "dependencies": {
@@ -2519,7 +2335,6 @@
     },
     "node_modules/@types/node": {
       "version": "24.13.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha1-SfGL08ZHhm3NpRoHVsFF4UWQzhY=",
       "license": "MIT",
       "dependencies": {
@@ -2528,7 +2343,6 @@
     },
     "node_modules/@types/sax": {
       "version": "1.2.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/sax/-/sax-1.2.7.tgz",
       "integrity": "sha1-ul/n35qpyJtt/3aIoZAj3SljCR0=",
       "license": "MIT",
       "dependencies": {
@@ -2537,26 +2351,22 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha1-usywepcLkXB986PoumiWxX6tLRE=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha1-rKqw+RnOaczmKcLU7S60rcG2wgw=",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha1-CUBB4aTLGYfwODNUISgayL45C8w=",
       "license": "ISC"
     },
     "node_modules/@upsetjs/venn.js": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
       "integrity": "sha1-O+GSA4zdqSeqT4siq1Gvgqv0fzQ=",
       "license": "MIT",
       "optionalDependencies": {
@@ -2566,7 +2376,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "license": "MIT",
       "bin": {
@@ -2578,7 +2387,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "license": "MIT",
       "peerDependencies": {
@@ -2587,7 +2395,6 @@
     },
     "node_modules/am-i-vibing": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
       "integrity": "sha1-Tbp96V+brbPmGg8Fk/rEOEpKvH4=",
       "license": "MIT",
       "dependencies": {
@@ -2599,7 +2406,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "license": "ISC",
       "dependencies": {
@@ -2612,7 +2418,6 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
@@ -2624,19 +2429,16 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/arg/-/arg-5.0.2.tgz",
       "integrity": "sha1-yBQzzEJ8ksTc9IZRQtvKbxWs1Zw=",
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha1-k/gaQ0gOM6M48ZFjo9EKUMAdzVk=",
       "license": "Apache-2.0",
       "engines": {
@@ -2645,7 +2447,6 @@
     },
     "node_modules/array-iterate": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/array-iterate/-/array-iterate-2.0.1.tgz",
       "integrity": "sha1-bv1D+ClbP+4GJR09YurUvZgF3SQ=",
       "license": "MIT",
       "funding": {
@@ -2655,7 +2456,6 @@
     },
     "node_modules/astring": {
       "version": "1.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astring/-/astring-1.9.0.tgz",
       "integrity": "sha1-zHPmBip+sD59GcItiws0Uf2b/u8=",
       "license": "MIT",
       "bin": {
@@ -2664,7 +2464,6 @@
     },
     "node_modules/astro": {
       "version": "7.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astro/-/astro-7.2.1.tgz",
       "integrity": "sha1-WR7OwVRtub4e6ISosfDBlRm8F+U=",
       "license": "MIT",
       "dependencies": {
@@ -2747,7 +2546,6 @@
     },
     "node_modules/astro-expressive-code": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astro-expressive-code/-/astro-expressive-code-0.44.1.tgz",
       "integrity": "sha1-3ar6xKhrRMmn7mW3WR46pT6lafE=",
       "license": "MIT",
       "dependencies": {
@@ -2760,7 +2558,6 @@
     },
     "node_modules/astro-mermaid": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astro-mermaid/-/astro-mermaid-2.1.0.tgz",
       "integrity": "sha1-Vvmmn/auSHyBCcM2gVfCHnxciqI=",
       "license": "MIT",
       "dependencies": {
@@ -2781,7 +2578,6 @@
     },
     "node_modules/astro/node_modules/magic-string": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-1.1.0.tgz",
       "integrity": "sha1-VKhHCqvyoEuXAXfybAMIyr6nSj8=",
       "license": "MIT",
       "dependencies": {
@@ -2790,7 +2586,6 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha1-KHaMdtDjz/IbxiqeLQtqwwBCoe4=",
       "license": "Apache-2.0",
       "engines": {
@@ -2799,7 +2594,6 @@
     },
     "node_modules/bail": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bail/-/bail-2.0.2.tgz",
       "integrity": "sha1-0m9c2P5db4MqMVF7n3w1YEC6bV0=",
       "license": "MIT",
       "funding": {
@@ -2809,7 +2603,6 @@
     },
     "node_modules/bcp-47": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bcp-47/-/bcp-47-2.1.1.tgz",
       "integrity": "sha1-8+kNN4shqh26bbOEXbzZW78dqqo=",
       "license": "MIT",
       "dependencies": {
@@ -2824,7 +2617,6 @@
     },
     "node_modules/bcp-47-match": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
       "integrity": "sha1-YDIm9uXTkUpYFAi+M7KKUxRLCdA=",
       "license": "MIT",
       "funding": {
@@ -2834,13 +2626,11 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "license": "ISC"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha1-F6O/gjAuCHDW2kOgExGovAKj7PU=",
       "license": "MIT",
       "funding": {
@@ -2850,7 +2640,6 @@
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha1-LQnC5yzZUjB2zLIRV9/2atQ/zCI=",
       "license": "MIT",
       "funding": {
@@ -2860,7 +2649,6 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha1-HxrblAyXGksiujndymthjcblays=",
       "license": "MIT",
       "funding": {
@@ -2870,7 +2658,6 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha1-dryDqQc4kB17wiOp6TdZ/dVgEls=",
       "license": "MIT",
       "funding": {
@@ -2880,7 +2667,6 @@
     },
     "node_modules/character-reference-invalid": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha1-hcZrBB5DtHIQ+vQBJ4q/gIrEXLk=",
       "license": "MIT",
       "funding": {
@@ -2890,7 +2676,6 @@
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha1-lJwSapI4qAeSvpoCZZNPCYrzaaU=",
       "license": "MIT",
       "dependencies": {
@@ -2905,7 +2690,6 @@
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha1-fVTv+fVLRbYkAcJgMmlutZyL0Yw=",
       "funding": [
         {
@@ -2920,7 +2704,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
       "license": "MIT",
       "engines": {
@@ -2929,7 +2712,6 @@
     },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
       "integrity": "sha1-ZAJXF0+fQsdAtA87Ve51KST+78o=",
       "license": "MIT",
       "funding": {
@@ -2939,7 +2721,6 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha1-TonJRYrLYbyP7xn0UplzsjkoOe4=",
       "license": "MIT",
       "funding": {
@@ -2949,7 +2730,6 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-7.2.0.tgz",
       "integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
       "license": "MIT",
       "engines": {
@@ -2958,7 +2738,6 @@
     },
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
       "integrity": "sha1-8dNhrqkjaq1bkqD/W53xQi3TYP8=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2967,7 +2746,6 @@
     },
     "node_modules/cookie": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-2.0.1.tgz",
       "integrity": "sha1-H8fpvd84+pVnzU11CCAIfNtdbpg=",
       "license": "MIT",
       "engines": {
@@ -2980,13 +2758,11 @@
     },
     "node_modules/cookie-es": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha1-Bso8X181MWhKIFlmajYRc/dKicg=",
       "license": "MIT"
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cose-base/-/cose-base-1.0.3.tgz",
       "integrity": "sha1-ZQM0tBuGlXilQzWLgM2n4Kvgpgo=",
       "license": "MIT",
       "dependencies": {
@@ -2995,7 +2771,6 @@
     },
     "node_modules/crossws": {
       "version": "0.3.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/crossws/-/crossws-0.3.5.tgz",
       "integrity": "sha1-2q0zHUQUjqZQAJi8hYhp86WrgaY=",
       "license": "MIT",
       "dependencies": {
@@ -3004,7 +2779,6 @@
     },
     "node_modules/css-select": {
       "version": "5.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha1-Abbo0WNje7LdbJgspO1lhjaCeG4=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3020,7 +2794,6 @@
     },
     "node_modules/css-selector-parser": {
       "version": "3.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
       "integrity": "sha1-GjQiDXZ2LJKa6ZmT31pgch9QUII=",
       "funding": [
         {
@@ -3036,7 +2809,6 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha1-hsrHARVhJysw5rHgQrps4EeqdRg=",
       "license": "MIT",
       "dependencies": {
@@ -3049,7 +2821,6 @@
     },
     "node_modules/css-what": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha1-zcyPm2l3cZ/fvR3nrsJKv3Vrneo=",
       "license": "BSD-2-Clause",
       "engines": {
@@ -3061,7 +2832,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "license": "MIT",
       "bin": {
@@ -3073,7 +2843,6 @@
     },
     "node_modules/csso": {
       "version": "5.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csso/-/csso-5.0.5.tgz",
       "integrity": "sha1-+bf+bMasC32QeBuxbV6YdDA+LKY=",
       "license": "MIT",
       "dependencies": {
@@ -3086,7 +2855,6 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-tree/-/css-tree-2.2.1.tgz",
       "integrity": "sha1-NhFdOC1gr9Jx43f5xfZ9Ar1IwDI=",
       "license": "MIT",
       "dependencies": {
@@ -3100,13 +2868,11 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha1-XsSOe+8SBlRTkGnhrk3cgcpJDro=",
       "license": "CC0-1.0"
     },
     "node_modules/cytoscape": {
       "version": "3.34.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cytoscape/-/cytoscape-3.34.1.tgz",
       "integrity": "sha1-Nkkju5WY9bwe0chJoSc2cRmCdfw=",
       "license": "MIT",
       "engines": {
@@ -3115,7 +2881,6 @@
     },
     "node_modules/cytoscape-cose-bilkent": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
       "integrity": "sha1-di+hId+ZMP/rUaSV2HkXxXCsIJs=",
       "license": "MIT",
       "dependencies": {
@@ -3127,7 +2892,6 @@
     },
     "node_modules/cytoscape-fcose": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
       "integrity": "sha1-5Nb2SQ30+rWK6c6p5cOrjXRy9HE=",
       "license": "MIT",
       "dependencies": {
@@ -3139,7 +2903,6 @@
     },
     "node_modules/cytoscape-fcose/node_modules/cose-base": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cose-base/-/cose-base-2.2.0.tgz",
       "integrity": "sha1-HDlcNbbhC7g/l2nKi4F9YUrdXAE=",
       "license": "MIT",
       "dependencies": {
@@ -3148,13 +2911,11 @@
     },
     "node_modules/cytoscape-fcose/node_modules/layout-base": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha1-0DN5E1hskPnCwHUpIGn1wtpd0oU=",
       "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3/-/d3-7.9.0.tgz",
       "integrity": "sha1-V556yz10nK+IYL0XQa6NNxBwzV0=",
       "license": "ISC",
       "dependencies": {
@@ -3195,7 +2956,6 @@
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha1-Ff7DOyN/l6xdfJhtx32ic6jtC7U=",
       "license": "ISC",
       "dependencies": {
@@ -3207,7 +2967,6 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-axis/-/d3-axis-3.0.0.tgz",
       "integrity": "sha1-xCpKE+gTHWN7dF/Clzgkz+r5MyI=",
       "license": "ISC",
       "engines": {
@@ -3216,7 +2975,6 @@
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-brush/-/d3-brush-3.0.0.tgz",
       "integrity": "sha1-b3Z8Ttjct53n7ePhwPieY+9k0xw=",
       "license": "ISC",
       "dependencies": {
@@ -3232,7 +2990,6 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-chord/-/d3-chord-3.0.1.tgz",
       "integrity": "sha1-0VbWH0hfzoMn5qvzOctB2Mu6aWY=",
       "license": "ISC",
       "dependencies": {
@@ -3244,7 +3001,6 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha1-OVsoM9+scVB/EqwvevI7+BneJOI=",
       "license": "ISC",
       "engines": {
@@ -3253,7 +3009,6 @@
     },
     "node_modules/d3-contour": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-contour/-/d3-contour-4.0.2.tgz",
       "integrity": "sha1-u5IGO8jFZjrLJCL5nHPLtsauO8w=",
       "license": "ISC",
       "dependencies": {
@@ -3265,7 +3020,6 @@
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha1-mBaQOHM6ClurvtpVBU95W7nkpYs=",
       "license": "ISC",
       "dependencies": {
@@ -3277,7 +3031,6 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha1-X8dShOnCN1w2yDlBGgz1UMv8TV4=",
       "license": "ISC",
       "engines": {
@@ -3286,7 +3039,6 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-drag/-/d3-drag-3.0.0.tgz",
       "integrity": "sha1-mUqunNI8cZ9TteEOOgphCMaWB7o=",
       "license": "ISC",
       "dependencies": {
@@ -3299,7 +3051,6 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-dsv/-/d3-dsv-3.0.1.tgz",
       "integrity": "sha1-xjr5ePTWoNCEpSpnOSK+IWB4m3M=",
       "license": "ISC",
       "dependencies": {
@@ -3324,7 +3075,6 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha1-llisOKIUDVnTRhYPH2ww/aC9EvQ=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -3333,7 +3083,6 @@
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-fetch/-/d3-fetch-3.0.1.tgz",
       "integrity": "sha1-gxQb/5hWoO21443onNz+Y9CmCiI=",
       "license": "ISC",
       "dependencies": {
@@ -3345,7 +3094,6 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-force/-/d3-force-3.0.0.tgz",
       "integrity": "sha1-Piuhph5wiI/j2RlOMNbRTuzhVcQ=",
       "license": "ISC",
       "dependencies": {
@@ -3359,7 +3107,6 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha1-Af20a1i+sfVbELQq1wtuNE1esq4=",
       "license": "ISC",
       "engines": {
@@ -3368,7 +3115,6 @@
     },
     "node_modules/d3-geo": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-geo/-/d3-geo-3.1.1.tgz",
       "integrity": "sha1-YCfPUSRvmy69ZPmeAdx8M2QDOk0=",
       "license": "ISC",
       "dependencies": {
@@ -3380,7 +3126,6 @@
     },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha1-sBzULB7tPUbbd6WWbPcm+MCRYMY=",
       "license": "ISC",
       "engines": {
@@ -3389,7 +3134,6 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha1-PEeqWzLFs9+1bvP9Q0IHimMrQA0=",
       "license": "ISC",
       "dependencies": {
@@ -3401,7 +3145,6 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha1-It+TkDL7WnGuixgA1h3beFHEJSY=",
       "license": "ISC",
       "engines": {
@@ -3410,7 +3153,6 @@
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-polygon/-/d3-polygon-3.0.1.tgz",
       "integrity": "sha1-C0XT3RxIopyOBX5hNWk+yAvxY5g=",
       "license": "ISC",
       "engines": {
@@ -3419,7 +3161,6 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha1-bco+i+Kzk8mp1RTau9gKkt7vGk8=",
       "license": "ISC",
       "engines": {
@@ -3428,7 +3169,6 @@
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-random/-/d3-random-3.0.1.tgz",
       "integrity": "sha1-1JJjeNMz2cC/0eb6AZTTCuuqIPQ=",
       "license": "ISC",
       "engines": {
@@ -3437,7 +3177,6 @@
     },
     "node_modules/d3-sankey": {
       "version": "0.12.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-sankey/-/d3-sankey-0.12.3.tgz",
       "integrity": "sha1-s8JoYnvXLl2AM26N5qy/7J0V0B0=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3447,7 +3186,6 @@
     },
     "node_modules/d3-sankey/node_modules/d3-array": {
       "version": "2.12.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha1-4gtBqvzf/fXVCSgATs7PgVpGXoE=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3456,13 +3194,11 @@
     },
     "node_modules/d3-sankey/node_modules/d3-path": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha1-SMBQux/owmJJOoyvVSTj6VkXAc8=",
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-sankey/node_modules/d3-shape": {
       "version": "1.3.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha1-32OAG+B7yYa8VPY3ibT+UCmStdc=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3471,13 +3207,11 @@
     },
     "node_modules/d3-sankey/node_modules/internmap": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha1-ABfMijuZYF8DAvKxmNJy4BXl35U=",
       "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha1-grOOjo/3CAdk+Nzsd71L45Nok5Y=",
       "license": "ISC",
       "dependencies": {
@@ -3493,7 +3227,6 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha1-NMOdopiyPCDgLxpLI5vQ8i5/ExQ=",
       "license": "ISC",
       "dependencies": {
@@ -3506,7 +3239,6 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha1-wlM4IH76csxbm9FFihpBkB8eGzE=",
       "license": "ISC",
       "engines": {
@@ -3515,7 +3247,6 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha1-oag5y9m6RfKGdMadf4Vbz5HfxqU=",
       "license": "ISC",
       "dependencies": {
@@ -3527,7 +3258,6 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha1-kxDbVumS48AXXh7zheVF5Iqbtcc=",
       "license": "ISC",
       "dependencies": {
@@ -3539,7 +3269,6 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha1-erUlelBB0R7LT+cKXH0WoZW7QIo=",
       "license": "ISC",
       "dependencies": {
@@ -3551,7 +3280,6 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha1-YoTSonCChbGrt+IB7aQ4CvNeY7A=",
       "license": "ISC",
       "engines": {
@@ -3560,7 +3288,6 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha1-aGn93hRIhoB3/dWYkgDLYbKhZF8=",
       "license": "ISC",
       "dependencies": {
@@ -3579,7 +3306,6 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-zoom/-/d3-zoom-3.0.0.tgz",
       "integrity": "sha1-0T9BZccyF//qpUKVzWlps+eu6PM=",
       "license": "ISC",
       "dependencies": {
@@ -3595,7 +3321,6 @@
     },
     "node_modules/dagre-d3-es": {
       "version": "7.0.14",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
       "integrity": "sha1-EnInbiZFfPO5faxWn48FMewzw3c=",
       "license": "MIT",
       "dependencies": {
@@ -3605,13 +3330,11 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.21",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dayjs/-/dayjs-1.11.21.tgz",
       "integrity": "sha1-V/h1YuYt5288cEvSuNUi/DMGjrI=",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
@@ -3628,7 +3351,6 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha1-PkBgN2CHTC5YZ2kbWZ1zp9oltT8=",
       "license": "MIT",
       "dependencies": {
@@ -3641,13 +3363,11 @@
     },
     "node_modules/defu": {
       "version": "6.1.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/defu/-/defu-6.1.7.tgz",
       "integrity": "sha1-clQ1Z8jp+X/xPOQCttvgmsWuTSM=",
       "license": "MIT"
     },
     "node_modules/delaunator": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/delaunator/-/delaunator-5.1.0.tgz",
       "integrity": "sha1-0TJx+/Ov9nU/nqbiNVV/IJAQRuo=",
       "license": "ISC",
       "dependencies": {
@@ -3656,7 +3376,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
       "license": "MIT",
       "engines": {
@@ -3665,13 +3384,11 @@
     },
     "node_modules/destr": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/destr/-/destr-2.0.5.tgz",
       "integrity": "sha1-fREv8bkl+40gefrFvbSpCXO1H9s=",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
       "license": "Apache-2.0",
       "engines": {
@@ -3680,13 +3397,11 @@
     },
     "node_modules/devalue": {
       "version": "5.9.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devalue/-/devalue-5.9.0.tgz",
       "integrity": "sha1-XTDbQaDbkXHPTunb9mF+C3fNfCo=",
       "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha1-TbfCyk3G4Og0wwvnDJS7yXbccBg=",
       "license": "MIT",
       "dependencies": {
@@ -3699,7 +3414,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/diff/-/diff-8.0.4.tgz",
       "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -3708,7 +3422,6 @@
     },
     "node_modules/direction": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/direction/-/direction-2.0.1.tgz",
       "integrity": "sha1-cYAN08T6ECQGUCkF04ZuZb3ruYU=",
       "license": "MIT",
       "bin": {
@@ -3721,7 +3434,6 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=",
       "license": "MIT",
       "dependencies": {
@@ -3735,7 +3447,6 @@
     },
     "node_modules/dom-serializer/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-4.5.0.tgz",
       "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
       "license": "BSD-2-Clause",
       "engines": {
@@ -3747,7 +3458,6 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=",
       "funding": [
         {
@@ -3759,7 +3469,6 @@
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3774,7 +3483,6 @@
     },
     "node_modules/dompurify": {
       "version": "3.4.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dompurify/-/dompurify-3.4.13.tgz",
       "integrity": "sha1-/CiUnVn5LWLiijp2S8vu41iXob4=",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -3783,7 +3491,6 @@
     },
     "node_modules/domutils": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha1-7b/itmiwwdl8JLrw8QYrEyIhvHg=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3797,7 +3504,6 @@
     },
     "node_modules/dset": {
       "version": "3.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dset/-/dset-3.1.4.tgz",
       "integrity": "sha1-+Or18CPwaKA20IzQfcn/t9AGUkg=",
       "license": "MIT",
       "engines": {
@@ -3806,13 +3512,11 @@
     },
     "node_modules/elkjs": {
       "version": "0.9.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/elkjs/-/elkjs-0.9.3.tgz",
       "integrity": "sha1-FnEfjOsJ8bErmelxsTioOEpSkWE=",
       "license": "EPL-2.0"
     },
     "node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-6.0.1.tgz",
       "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
       "license": "BSD-2-Clause",
       "engines": {
@@ -3824,13 +3528,11 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
       "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.50.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-toolkit/-/es-toolkit-1.50.0.tgz",
       "integrity": "sha1-JmXCHQq3Yob0eOzjojVGMJeuq9M=",
       "license": "MIT",
       "workspaces": [
@@ -3841,7 +3543,6 @@
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
       "integrity": "sha1-jRz7Ua1TTS8VncJQ5gTzR4p58a0=",
       "license": "MIT",
       "dependencies": {
@@ -3857,7 +3558,6 @@
     },
     "node_modules/esast-util-from-js": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
       "integrity": "sha1-UUe+w0zJ2kSsz1L4fyOaQKw+giU=",
       "license": "MIT",
       "dependencies": {
@@ -3873,7 +3573,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.28.2.tgz",
       "integrity": "sha1-D0O9G62VW3LSTiJh46vllXzPCBY=",
       "hasInstallScript": true,
       "license": "MIT",
@@ -3914,7 +3613,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg=",
       "license": "MIT",
       "engines": {
@@ -3926,7 +3624,6 @@
     },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
       "integrity": "sha1-NEveamTIox0VIx5e6eKXVmppHC0=",
       "license": "MIT",
       "dependencies": {
@@ -3939,7 +3636,6 @@
     },
     "node_modules/estree-util-build-jsx": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
       "integrity": "sha1-ttC87R3MTwbyXPDO2istyvmBaPE=",
       "license": "MIT",
       "dependencies": {
@@ -3955,7 +3651,6 @@
     },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
       "integrity": "sha1-C170xP8TUIs03NAez6lF9h/OXb0=",
       "license": "MIT",
       "funding": {
@@ -3965,7 +3660,6 @@
     },
     "node_modules/estree-util-scope": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
       "integrity": "sha1-nL38d/XLUePZ7UrZxK2/8i1D5YU=",
       "license": "MIT",
       "dependencies": {
@@ -3979,7 +3673,6 @@
     },
     "node_modules/estree-util-to-js": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
       "integrity": "sha1-EKb7kkgU5qu2K+zw0rxN6lHQTxc=",
       "license": "MIT",
       "dependencies": {
@@ -3994,7 +3687,6 @@
     },
     "node_modules/estree-util-visit": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
       "integrity": "sha1-E6mp9A/1DtDAIvgx3fS1jQVEb+s=",
       "license": "MIT",
       "dependencies": {
@@ -4008,7 +3700,6 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
       "license": "MIT",
       "dependencies": {
@@ -4017,13 +3708,11 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha1-qG1mFwQzcS3egUcHrFK1JxzrH+s=",
       "license": "MIT"
     },
     "node_modules/expressive-code": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expressive-code/-/expressive-code-0.44.1.tgz",
       "integrity": "sha1-gaKP35qNRiJv8qNkoTtlQITGe2E=",
       "license": "MIT",
       "dependencies": {
@@ -4035,19 +3724,16 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
       "integrity": "sha1-I6/g2mfXUsoHJ1OPHmlndZcozkk=",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-string-width/-/fast-string-width-3.0.2.tgz",
       "integrity": "sha1-FturtJHOVYW17LZ1tlwWXXFojus=",
       "license": "MIT",
       "dependencies": {
@@ -4056,7 +3742,6 @@
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
       "integrity": "sha1-lelSoBRbzj9ZrVbhefhMSNQHKTU=",
       "license": "MIT",
       "dependencies": {
@@ -4065,7 +3750,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "license": "MIT",
       "engines": {
@@ -4082,7 +3766,6 @@
     },
     "node_modules/flattie": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/flattie/-/flattie-1.1.1.tgz",
       "integrity": "sha1-iBgiNXIxE2Z9NiF/7FU1knXW/j0=",
       "license": "MIT",
       "engines": {
@@ -4091,7 +3774,6 @@
     },
     "node_modules/fontace": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fontace/-/fontace-0.4.1.tgz",
       "integrity": "sha1-3ip2zzYQiAFpAabyqPK9AWya6EQ=",
       "license": "MIT",
       "dependencies": {
@@ -4100,7 +3782,6 @@
     },
     "node_modules/fontkitten": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fontkitten/-/fontkitten-1.0.3.tgz",
       "integrity": "sha1-u6/e3bseBUln8IRv3HV6zKuIu2g=",
       "license": "MIT",
       "dependencies": {
@@ -4112,7 +3793,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "license": "MIT",
       "optional": true,
@@ -4125,7 +3805,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "5.0.0-beta.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
       "integrity": "sha1-SOHISRnRb9Ht/r0E6JWNqUKUXCU=",
       "license": "MIT",
       "dependencies": {
@@ -4140,13 +3819,11 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha1-Us8vknmiHrbFndOFtBDwwK3ajxo=",
       "license": "ISC"
     },
     "node_modules/h3": {
       "version": "1.15.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/h3/-/h3-1.15.11.tgz",
       "integrity": "sha1-gxF5/GtLwG3orRB356XH1jt5ZXc=",
       "license": "MIT",
       "dependencies": {
@@ -4163,13 +3840,11 @@
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha1-0ZvEzIdQpZYrR/sTAFV6hfz5NMw=",
       "license": "MIT"
     },
     "node_modules/hast-util-embedded": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
       "integrity": "sha1-vkR3eA+74HnNuiKYLjV6DeS6hT4=",
       "license": "MIT",
       "dependencies": {
@@ -4183,7 +3858,6 @@
     },
     "node_modules/hast-util-format": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-format/-/hast-util-format-1.1.0.tgz",
       "integrity": "sha1-Nz53OC4H3rBPZnbxtEN+fYVJ2YU=",
       "license": "MIT",
       "dependencies": {
@@ -4202,7 +3876,6 @@
     },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
       "integrity": "sha1-SFx0eFNYvrgMS6Y0YpkxGsTEnII=",
       "license": "MIT",
       "dependencies": {
@@ -4220,7 +3893,6 @@
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
       "integrity": "sha1-gwo1Ai//KMP+o2l6mML0zGuDWi4=",
       "license": "MIT",
       "dependencies": {
@@ -4240,7 +3912,6 @@
     },
     "node_modules/hast-util-has-property": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
       "integrity": "sha1-TllePN24zlMOqS9vxBEagY2Of5M=",
       "license": "MIT",
       "dependencies": {
@@ -4253,7 +3924,6 @@
     },
     "node_modules/hast-util-is-body-ok-link": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
       "integrity": "sha1-72PLLxTwTs93UTnNkr2lAmOA2LQ=",
       "license": "MIT",
       "dependencies": {
@@ -4266,7 +3936,6 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha1-bjGmUywhfltTOEjH5Sydk2nKCTI=",
       "license": "MIT",
       "dependencies": {
@@ -4279,7 +3948,6 @@
     },
     "node_modules/hast-util-minify-whitespace": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
       "integrity": "sha1-dYj9GlP0jx0wQGuBlZ3/w2UNr1U=",
       "license": "MIT",
       "dependencies": {
@@ -4296,7 +3964,6 @@
     },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha1-NSh5+obiVhYDYDfdiTH7XzTLSic=",
       "license": "MIT",
       "dependencies": {
@@ -4309,7 +3976,6 @@
     },
     "node_modules/hast-util-phrasing": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
       "integrity": "sha1-+ihMDNSoKg3WAg3oMAp7Hr/6FpA=",
       "license": "MIT",
       "dependencies": {
@@ -4326,7 +3992,6 @@
     },
     "node_modules/hast-util-raw": {
       "version": "9.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
       "integrity": "sha1-ebZrJvb2j7UN+0cWss3KkNkq3y4=",
       "license": "MIT",
       "dependencies": {
@@ -4351,7 +4016,6 @@
     },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-select/-/hast-util-select-6.0.4.tgz",
       "integrity": "sha1-HY9pZXpXRB0M4K3jWIeHTT5lowM=",
       "license": "MIT",
       "dependencies": {
@@ -4378,7 +4042,6 @@
     },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
       "integrity": "sha1-5lTByTdGRRNWlcwKufcLj8r3M9c=",
       "license": "MIT",
       "dependencies": {
@@ -4406,7 +4069,6 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha1-zMZzpVu46Fd1sIrCg4D3LUcWcAU=",
       "license": "MIT",
       "dependencies": {
@@ -4429,7 +4091,6 @@
     },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
       "integrity": "sha1-/zGJeq5Z9iIy4hWU6sfva2MzPpg=",
       "license": "MIT",
       "dependencies": {
@@ -4456,7 +4117,6 @@
     },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
       "integrity": "sha1-lao5HMBRS0lRQY0ByIPRA4r0L10=",
       "license": "MIT",
       "dependencies": {
@@ -4475,7 +4135,6 @@
     },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
       "integrity": "sha1-pPFeaChJMm3SEclxKclLDD52Unw=",
       "license": "MIT",
       "dependencies": {
@@ -4488,7 +4147,6 @@
     },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
       "integrity": "sha1-V7Z2kx5xv5y4UkU2eElbMIC/rj4=",
       "license": "MIT",
       "dependencies": {
@@ -4504,7 +4162,6 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha1-d3jtnTyS3Z6MXI9kiknCH8UctiE=",
       "license": "MIT",
       "dependencies": {
@@ -4517,7 +4174,6 @@
     },
     "node_modules/hastscript": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hastscript/-/hastscript-9.0.1.tgz",
       "integrity": "sha1-28hL72BR1ACENCwinEUc2dxWff8=",
       "license": "MIT",
       "dependencies": {
@@ -4534,13 +4190,11 @@
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha1-TTNmdGUr6x3Lwp72trp/a+b9/tY=",
       "license": "MIT"
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha1-/J29hK+edHJJA01NYmAt72UX8dc=",
       "license": "MIT",
       "funding": {
@@ -4550,7 +4204,6 @@
     },
     "node_modules/html-whitespace-sensitive-tag-names": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
       "integrity": "sha1-w17dKCBfO/jB/QMnRgjWC5I95bI=",
       "license": "MIT",
       "funding": {
@@ -4560,13 +4213,11 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha1-IF9Ntk+FYrdqT/kjWqUnmDmgndU=",
       "license": "BSD-2-Clause"
     },
     "node_modules/i18next": {
       "version": "26.3.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/i18next/-/i18next-26.3.6.tgz",
       "integrity": "sha1-WZ2ydcULZtKKadj2xRYsJFzpKWs=",
       "funding": [
         {
@@ -4594,7 +4245,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
       "license": "MIT",
       "dependencies": {
@@ -4606,7 +4256,6 @@
     },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
       "integrity": "sha1-CMuFtb037MjrHg9nDcJ2cALUNzQ=",
       "license": "MIT",
       "funding": {
@@ -4616,13 +4265,11 @@
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha1-sfxov8AxO4aFdF5EZON/k3a5yQk=",
       "license": "MIT"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha1-ZoXyN1XkPFJOJR0py8lySOMGEAk=",
       "license": "ISC",
       "engines": {
@@ -4631,7 +4278,6 @@
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
       "integrity": "sha1-qmD/KqEFUGMPTAsR/SRCvs2zWm8=",
       "license": "MIT",
       "funding": {
@@ -4640,7 +4286,6 @@
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha1-AQcgU+p8EDbfPH0Zptqux/GeeJs=",
       "license": "MIT",
       "funding": {
@@ -4650,7 +4295,6 @@
     },
     "node_modules/is-alphanumerical": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha1-fAP76W4+kxET5X+WSwo2jMLf2HU=",
       "license": "MIT",
       "dependencies": {
@@ -4664,7 +4308,6 @@
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha1-lGnS3BkNAhT9h9eLeMrswMwU7vc=",
       "license": "MIT",
       "funding": {
@@ -4674,7 +4317,6 @@
     },
     "node_modules/is-docker": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-docker/-/is-docker-4.0.0.tgz",
       "integrity": "sha1-aquHx3ow3f85xGCvNy7heVrueEg=",
       "license": "MIT",
       "bin": {
@@ -4689,7 +4331,6 @@
     },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha1-hrW/Zo/KMHSY0xnfwDKJ14GpACc=",
       "license": "MIT",
       "funding": {
@@ -4699,7 +4340,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha1-1lAl7ew2V84DL9fbY8l4g+rtcfA=",
       "license": "MIT",
       "engines": {
@@ -4711,7 +4351,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "funding": [
         {
@@ -4733,13 +4372,11 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha1-8qUktPf9EePXkeVZl3rWC5i3mLQ=",
       "license": "MIT"
     },
     "node_modules/katex": {
       "version": "0.16.47",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/katex/-/katex-0.16.47.tgz",
       "integrity": "sha1-ChOkLC3rT3TmHxYtRAuRZaVIAw8=",
       "funding": [
         "https://opencollective.com/katex",
@@ -4755,7 +4392,6 @@
     },
     "node_modules/katex/node_modules/commander": {
       "version": "8.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-8.3.0.tgz",
       "integrity": "sha1-SDfqGy2me5xhamevuw+v7lZ7ymY=",
       "license": "MIT",
       "engines": {
@@ -4764,12 +4400,10 @@
     },
     "node_modules/khroma": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha1-RfLOlM4jGkN89bY8LohubrQru7E="
     },
     "node_modules/klona": {
       "version": "2.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/klona/-/klona-2.0.6.tgz",
       "integrity": "sha1-hb/7+BnAOy9TJwQSQgpFVe+ILiI=",
       "license": "MIT",
       "engines": {
@@ -4778,13 +4412,11 @@
     },
     "node_modules/layout-base": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha1-EpHilog8Miqd1MXdggY3IbU+JuI=",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.33.0.tgz",
       "integrity": "sha1-wIhn1xp5OFxuGQIU/XL+8+X5Xws=",
       "license": "MPL-2.0",
       "dependencies": {
@@ -4813,7 +4445,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
       "integrity": "sha1-mmhB+IrlD8g1ApA4krQa9BvCuQc=",
       "cpu": [
         "arm64"
@@ -4833,7 +4464,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
       "integrity": "sha1-wPLDHAv9GfpN0/GOlXofGhUgl9Y=",
       "cpu": [
         "arm64"
@@ -4853,7 +4483,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
       "integrity": "sha1-ywcFllrLU4xmg5Sc5pJfs833w2E=",
       "cpu": [
         "x64"
@@ -4873,7 +4502,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
       "integrity": "sha1-djU4gosmurJoDa2vzITueLDrUCs=",
       "cpu": [
         "x64"
@@ -4893,7 +4521,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
       "integrity": "sha1-aGLjF2ozGu297B7TUrTX0N0HhN4=",
       "cpu": [
         "arm"
@@ -4913,7 +4540,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
       "integrity": "sha1-xqOi7RUUHa9r3CYokw+OOb30c6o=",
       "cpu": [
         "arm64"
@@ -4933,7 +4559,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
       "integrity": "sha1-f6EzSXH8goRfmCffbvigsgkUusY=",
       "cpu": [
         "arm64"
@@ -4953,7 +4578,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
       "integrity": "sha1-i5J4YuqMK7xoMaRlCSRLUNmTblU=",
       "cpu": [
         "x64"
@@ -4973,7 +4597,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
       "integrity": "sha1-DFJbsHff2UQEwFnP5C2teX6Wrq8=",
       "cpu": [
         "x64"
@@ -4993,7 +4616,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
       "integrity": "sha1-hQ7hED2smJz6tQ46wi0aaeOU5j0=",
       "cpu": [
         "arm64"
@@ -5013,7 +4635,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.33.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
       "integrity": "sha1-40OuFS7tNgncbhGUnRo785oclG8=",
       "cpu": [
         "x64"
@@ -5033,13 +4654,11 @@
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha1-uWLuuA2dmDqQC/NClh+3QYyhCx0=",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha1-YvpnzZWHQqFXSvnzmGY2QQLZDNQ=",
       "license": "MIT",
       "funding": {
@@ -5049,7 +4668,6 @@
     },
     "node_modules/lru-cache": {
       "version": "11.5.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha1-AOFmZckMYg+6FKPDaHMql2ST92A=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5058,7 +4676,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE=",
       "license": "MIT",
       "dependencies": {
@@ -5067,7 +4684,6 @@
     },
     "node_modules/magicast": {
       "version": "0.5.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magicast/-/magicast-0.5.4.tgz",
       "integrity": "sha1-u+ON/WA3ZwBX8zq/IriqedXpnQo=",
       "license": "MIT",
       "dependencies": {
@@ -5078,7 +4694,6 @@
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
       "integrity": "sha1-NL68g+mTjK4W4OAX5KmBSoMw08Q=",
       "license": "MIT",
       "engines": {
@@ -5090,7 +4705,6 @@
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha1-/kTW1BD/nW8uoXl6P2CqTStjHCo=",
       "license": "MIT",
       "funding": {
@@ -5100,7 +4714,6 @@
     },
     "node_modules/marked": {
       "version": "16.4.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/marked/-/marked-16.4.2.tgz",
       "integrity": "sha1-SVmmS+bEhvDbdGfq184ojeVCkKM=",
       "license": "MIT",
       "bin": {
@@ -5112,7 +4725,6 @@
     },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
       "integrity": "sha1-wbtwbl52u5P5oJ3XrxdAAq5prCQ=",
       "license": "MIT",
       "dependencies": {
@@ -5127,7 +4739,6 @@
     },
     "node_modules/mdast-util-directive": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
       "integrity": "sha1-82VvSqtq43Z9PHLPq16AVVcsy6E=",
       "license": "MIT",
       "dependencies": {
@@ -5148,7 +4759,6 @@
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha1-cKMXTIlOFN9yKr9DvCUMuuRLEd8=",
       "license": "MIT",
       "dependencies": {
@@ -5164,7 +4774,6 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha1-yVgiuRqrdfGKTL6LL1G4c+0s8Mc=",
       "license": "MIT",
       "dependencies": {
@@ -5188,7 +4797,6 @@
     },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha1-LN9juSwqMxQGsPsNtMB3wbAzF1E=",
       "license": "MIT",
       "dependencies": {
@@ -5207,7 +4815,6 @@
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha1-q9VXYwM3vTCm1aS9glLhwtwIddU=",
       "license": "MIT",
       "dependencies": {
@@ -5224,7 +4831,6 @@
     },
     "node_modules/mdast-util-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha1-d3jp2co99yOMwr0/orG/amWxlAM=",
       "license": "MIT",
       "dependencies": {
@@ -5241,7 +4847,6 @@
     },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha1-1E756O0oOsjBFlqw0N/QWMJ2TBY=",
       "license": "MIT",
       "dependencies": {
@@ -5256,7 +4861,6 @@
     },
     "node_modules/mdast-util-gfm-table": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha1-ekNftiI6crCGKzOvvXErba6HjTg=",
       "license": "MIT",
       "dependencies": {
@@ -5273,7 +4877,6 @@
     },
     "node_modules/mdast-util-gfm-task-list-item": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha1-5oCV0vikMD7yQJSrZC4QR7mRqTY=",
       "license": "MIT",
       "dependencies": {
@@ -5289,7 +4892,6 @@
     },
     "node_modules/mdast-util-mdx": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
       "integrity": "sha1-eS+c8DYbRr7h/fHvNr6sQkoJnEE=",
       "license": "MIT",
       "dependencies": {
@@ -5306,7 +4908,6 @@
     },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
       "integrity": "sha1-Q/CrrJrcdW4ghvY4IqOMjTw6UJY=",
       "license": "MIT",
       "dependencies": {
@@ -5324,7 +4925,6 @@
     },
     "node_modules/mdast-util-mdx-jsx": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
       "integrity": "sha1-/QTGeip0me+5BailxXjd3J/a2g0=",
       "license": "MIT",
       "dependencies": {
@@ -5348,7 +4948,6 @@
     },
     "node_modules/mdast-util-mdxjs-esm": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
       "integrity": "sha1-AZz751etYt1VfbNaaV5zFLzJ+pc=",
       "license": "MIT",
       "dependencies": {
@@ -5366,7 +4965,6 @@
     },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha1-fMCo3sMOrwS3salmGpKtszgqpuM=",
       "license": "MIT",
       "dependencies": {
@@ -5380,7 +4978,6 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha1-1/+EykmaV+LAYK5nVIrZUOaJoFM=",
       "license": "MIT",
       "dependencies": {
@@ -5401,7 +4998,6 @@
     },
     "node_modules/mdast-util-to-markdown": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha1-+RD/5giX8Eu0t+fuQ0SG92KINhs=",
       "license": "MIT",
       "dependencies": {
@@ -5422,7 +5018,6 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha1-elEhR1VWoE5+3etnsmSq550xKBQ=",
       "license": "MIT",
       "dependencies": {
@@ -5435,13 +5030,11 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha1-43ucUIgLdTZsTUCsY9m7ys22Hw4=",
       "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
       "version": "11.16.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mermaid/-/mermaid-11.16.1.tgz",
       "integrity": "sha1-V64jQvbEW5ZxE7BMklhDC90Ffug=",
       "license": "MIT",
       "dependencies": {
@@ -5470,7 +5063,6 @@
     },
     "node_modules/micromark": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha1-kTlaPhiEoZjmIRbjPJxWjjmTb9s=",
       "funding": [
         {
@@ -5505,7 +5097,6 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha1-xpFjDkhQIaaM8o28Kyyifr9njNQ=",
       "funding": [
         {
@@ -5539,7 +5130,6 @@
     },
     "node_modules/micromark-extension-directive": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
       "integrity": "sha1-rzieM/4GVMFfhGa3Og9a9ZjQA2g=",
       "license": "MIT",
       "dependencies": {
@@ -5558,7 +5148,6 @@
     },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha1-PhM3arld16XP0OKVYN/pmWV7PFs=",
       "license": "MIT",
       "dependencies": {
@@ -5578,7 +5167,6 @@
     },
     "node_modules/micromark-extension-gfm-autolink-literal": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha1-Yoau6WhsRGLB41UqnVBf7dzuuTU=",
       "license": "MIT",
       "dependencies": {
@@ -5594,7 +5182,6 @@
     },
     "node_modules/micromark-extension-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha1-TatW1OOYuYU/b+TvrE/JNh8+B1A=",
       "license": "MIT",
       "dependencies": {
@@ -5614,7 +5201,6 @@
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha1-hhBt+LOmkrX2qSKA04eb5r5G2SM=",
       "license": "MIT",
       "dependencies": {
@@ -5632,7 +5218,6 @@
     },
     "node_modules/micromark-extension-gfm-table": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha1-+scLy/Uf5l9fRAMxGNOb6Km1lAs=",
       "license": "MIT",
       "dependencies": {
@@ -5649,7 +5234,6 @@
     },
     "node_modules/micromark-extension-gfm-tagfilter": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha1-8m2KeAe1mF+6E89hRltYyl/33Fc=",
       "license": "MIT",
       "dependencies": {
@@ -5662,7 +5246,6 @@
     },
     "node_modules/micromark-extension-gfm-task-list-item": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha1-vMNNgFY5gpmQ7BdcPuoSu1t4Hyw=",
       "license": "MIT",
       "dependencies": {
@@ -5679,7 +5262,6 @@
     },
     "node_modules/micromark-extension-mdx-expression": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
       "integrity": "sha1-Q9BY2ZlTL7MEEZWjw8BcRvqEVDs=",
       "funding": [
         {
@@ -5705,7 +5287,6 @@
     },
     "node_modules/micromark-extension-mdx-jsx": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
       "integrity": "sha1-/8mL22SXmJAvqfxWifZ/nByQIEQ=",
       "license": "MIT",
       "dependencies": {
@@ -5727,7 +5308,6 @@
     },
     "node_modules/micromark-extension-mdx-md": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
       "integrity": "sha1-HSUogeo110aYQjq0SRfh9bGXuS0=",
       "license": "MIT",
       "dependencies": {
@@ -5740,7 +5320,6 @@
     },
     "node_modules/micromark-extension-mdxjs": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
       "integrity": "sha1-taLg7USSiPP29sVENYFZVXVJ3hg=",
       "license": "MIT",
       "dependencies": {
@@ -5760,7 +5339,6 @@
     },
     "node_modules/micromark-extension-mdxjs-esm": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
       "integrity": "sha1-3iGysEX9IFm9ANNnRggd44OQ1Uo=",
       "license": "MIT",
       "dependencies": {
@@ -5781,7 +5359,6 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha1-j++OD3CB8EdPvdkt61DJkKAmRjk=",
       "funding": [
         {
@@ -5802,7 +5379,6 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha1-UmfvqX8eUlTvx/ILRZo4yyEFi6E=",
       "funding": [
         {
@@ -5824,7 +5400,6 @@
     },
     "node_modules/micromark-factory-mdx-expression": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
       "integrity": "sha1-uwmYhhBYnAfRweRCUoWJUEGz36k=",
       "funding": [
         {
@@ -5851,7 +5426,6 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha1-NtAhLpYrKzEh+FJfx6PHwCnzNPw=",
       "funding": [
         {
@@ -5871,7 +5445,6 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha1-I35KpdWKlYY/AQMtnumwkPHebpQ=",
       "funding": [
         {
@@ -5893,7 +5466,6 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha1-BrJrKYPE0nv8xlezPiUTTUhosLE=",
       "funding": [
         {
@@ -5915,7 +5487,6 @@
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha1-L5h4MaQNTFEKwmHomFLE6XA8zaY=",
       "funding": [
         {
@@ -5935,7 +5506,6 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha1-R/vNk0caP8yrhs/wOEf8NVLbEFE=",
       "funding": [
         {
@@ -5954,7 +5524,6 @@
     },
     "node_modules/micromark-util-classify-character": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha1-05n6+cRcoUyLS+mLHqSBvO2Htik=",
       "funding": [
         {
@@ -5975,7 +5544,6 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha1-Kg9JCrCL/1zC/V7sbdDKBPibMKk=",
       "funding": [
         {
@@ -5995,7 +5563,6 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha1-/PFbZgl5OI5vEYzba/fXnXPSb+U=",
       "funding": [
         {
@@ -6014,7 +5581,6 @@
     },
     "node_modules/micromark-util-decode-string": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha1-bLmVguXScehO/KjmGoB5lNcWHrI=",
       "funding": [
         {
@@ -6036,7 +5602,6 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha1-DVHRwJVVHPqsNoMmljz1XxX1QLg=",
       "funding": [
         {
@@ -6052,7 +5617,6 @@
     },
     "node_modules/micromark-util-events-to-acorn": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
       "integrity": "sha1-56imtVpH5aBscg1aHEq66MN8mPM=",
       "funding": [
         {
@@ -6077,7 +5641,6 @@
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha1-5AQDCWSBmGtBwQZif5j3LU0QuCU=",
       "funding": [
         {
@@ -6093,7 +5656,6 @@
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha1-ww13sugyrPZSb4vxqke8nJQ4wW0=",
       "funding": [
         {
@@ -6112,7 +5674,6 @@
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha1-4aLWLN0jcjCirhGDkCexk4HjHos=",
       "funding": [
         {
@@ -6131,7 +5692,6 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha1-q4l4m4GKWHUrc9a1UjhiG3+qj9c=",
       "funding": [
         {
@@ -6152,7 +5712,6 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha1-2K3lug8xl6HPaimZ+7/mNXoaGe4=",
       "funding": [
         {
@@ -6174,7 +5733,6 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha1-5dpJTo6ysHGg0I+zT2zv7GwKGbg=",
       "funding": [
         {
@@ -6190,7 +5748,6 @@
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha1-8AIl9fWg68MlT5bDa2YFxLOTkI4=",
       "funding": [
         {
@@ -6206,7 +5763,6 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mrmime/-/mrmime-2.0.1.tgz",
       "integrity": "sha1-vD6H95h4U6VMmFDusfEHjNRK3dw=",
       "license": "MIT",
       "engines": {
@@ -6215,13 +5771,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "funding": [
         {
@@ -6239,7 +5793,6 @@
     },
     "node_modules/neotraverse": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/neotraverse/-/neotraverse-1.0.1.tgz",
       "integrity": "sha1-fIm0P2UE74WSjHGPV4xoYhV20ZQ=",
       "license": "MIT",
       "engines": {
@@ -6248,7 +5801,6 @@
     },
     "node_modules/nlcst-to-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
       "integrity": "sha1-BVEehGHr+0FZUusLfpoafUBHG9Q=",
       "license": "MIT",
       "dependencies": {
@@ -6261,19 +5813,16 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha1-nQnKYwZsxIQjIR7UyvXXAHXXanE=",
       "license": "MIT"
     },
     "node_modules/node-mock-http": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-mock-http/-/node-mock-http-1.0.5.tgz",
       "integrity": "sha1-SXvC890gjm4/fAbLtKNCX4mf6Bg=",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "license": "MIT",
       "engines": {
@@ -6282,7 +5831,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha1-yeq0KO/842zWuSySS9sADvHx7R0=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6294,7 +5842,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/obug/-/obug-2.1.4.tgz",
       "integrity": "sha1-kJDYpUilIlF5FdKqaq6QcZesbPg=",
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -6307,7 +5854,6 @@
     },
     "node_modules/ofetch": {
       "version": "1.5.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ofetch/-/ofetch-1.5.1.tgz",
       "integrity": "sha1-XEPMVuAzmLJzAUlXBgNEJUUFxcc=",
       "license": "MIT",
       "dependencies": {
@@ -6318,19 +5864,16 @@
     },
     "node_modules/ohash": {
       "version": "2.0.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha1-YLEejP9iyp3uiNE3R6W6oUX1kAs=",
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
       "integrity": "sha1-4nykRvf88JaWYqOrm09DF21isTk=",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
       "version": "4.3.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
       "integrity": "sha1-Q+ZAKAJBsNaHoxTnpkHUdkB6HE0=",
       "license": "MIT",
       "dependencies": {
@@ -6341,7 +5884,6 @@
     },
     "node_modules/p-limit": {
       "version": "7.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-7.3.1.tgz",
       "integrity": "sha1-3tSMv6ELFhqZKBICYfqCyaKC6z8=",
       "license": "MIT",
       "dependencies": {
@@ -6356,7 +5898,6 @@
     },
     "node_modules/p-queue": {
       "version": "9.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-queue/-/p-queue-9.3.3.tgz",
       "integrity": "sha1-xeUox+s2G3uo61qUBpAvfy51/I8=",
       "license": "MIT",
       "dependencies": {
@@ -6372,7 +5913,6 @@
     },
     "node_modules/p-timeout": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha1-lWgKaqaTxTDxSsM3uL0y1Oxq5PA=",
       "license": "MIT",
       "engines": {
@@ -6384,13 +5924,11 @@
     },
     "node_modules/package-manager-detector": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
       "integrity": "sha1-cMmixL0aUT3NbK0Aap/OvsIqElM=",
       "license": "MIT"
     },
     "node_modules/pagefind": {
       "version": "1.5.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pagefind/-/pagefind-1.5.2.tgz",
       "integrity": "sha1-RH3YABjX/QwpJKVmOfe3K7vR8WU=",
       "license": "MIT",
       "bin": {
@@ -6408,7 +5946,6 @@
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha1-YdRvXtKOTuYundxD1rAQGIRD8Vk=",
       "license": "MIT",
       "dependencies": {
@@ -6427,13 +5964,11 @@
     },
     "node_modules/parse-entities/node_modules/@types/unist": {
       "version": "2.0.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha1-Ea9XsSfjJId3SEH3pOVOqxZtA8Q=",
       "license": "MIT"
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-latin/-/parse-latin-7.0.0.tgz",
       "integrity": "sha1-jfrKwm+mA/dkF/NiM/xFYCoyPh0=",
       "license": "MIT",
       "dependencies": {
@@ -6451,7 +5986,6 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha1-1+Ik+nI5nHoXUJn0X8KtAksF7AU=",
       "license": "MIT",
       "dependencies": {
@@ -6463,25 +5997,21 @@
     },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha1-j1ulzHD8e+yz3O+uoI4mWaumC4w=",
       "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/piccolore/-/piccolore-0.1.3.tgz",
       "integrity": "sha1-7zP2GA5qN7Nf4SpFdlqQAXHPrtw=",
       "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "license": "MIT",
       "engines": {
@@ -6493,13 +6023,11 @@
     },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/points-on-curve/-/points-on-curve-0.2.0.tgz",
       "integrity": "sha1-fbuYxDeRhZQ0KEdhMw+ok8uBtNE=",
       "license": "MIT"
     },
     "node_modules/points-on-path": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/points-on-path/-/points-on-path-0.2.1.tgz",
       "integrity": "sha1-VTICtUJMU77TcTWzGIWOrP+F3VI=",
       "license": "MIT",
       "dependencies": {
@@ -6509,7 +6037,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.26",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.26.tgz",
       "integrity": "sha1-bnUTV4DH4Q3zQzvyJmxVLTXIxiA=",
       "funding": [
         {
@@ -6537,7 +6064,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha1-TC0iq18gucth4sXFkVlQeE0GgTE=",
       "funding": [
         {
@@ -6562,7 +6088,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha1-/exMqA9Xgb0hbKm/iaKg/M//pfA=",
       "license": "MIT",
       "dependencies": {
@@ -6575,7 +6100,6 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha1-2XCZadnU4WQD9vNIxjVTsZ8Jdak=",
       "license": "MIT",
       "engines": {
@@ -6584,7 +6108,6 @@
     },
     "node_modules/process-ancestry": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/process-ancestry/-/process-ancestry-0.1.0.tgz",
       "integrity": "sha1-BqGLsGxBPYJ1AhkEWPx2BO5rPe0=",
       "license": "MIT",
       "engines": {
@@ -6593,7 +6116,6 @@
     },
     "node_modules/property-information": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/property-information/-/property-information-7.2.0.tgz",
       "integrity": "sha1-CAmzQmTplcC/zTInAooeNSEK+Ao=",
       "license": "MIT",
       "funding": {
@@ -6603,13 +6125,11 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha1-/SfSrziWxr9Lzfq2Qnxpwq/GnsA=",
       "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-5.1.1.tgz",
       "integrity": "sha1-UgvKBvnRrhuWzAgA2+hLmD0ZQiw=",
       "license": "MIT",
       "engines": {
@@ -6622,7 +6142,6 @@
     },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
       "integrity": "sha1-wC8p4EfhA9L6sgVJVOF2G46iU8Q=",
       "license": "MIT",
       "dependencies": {
@@ -6637,7 +6156,6 @@
     },
     "node_modules/recma-jsx": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recma-jsx/-/recma-jsx-1.0.1.tgz",
       "integrity": "sha1-WOcY9F4hAu0L8vqZTwW3DXaAGho=",
       "license": "MIT",
       "dependencies": {
@@ -6657,7 +6175,6 @@
     },
     "node_modules/recma-parse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recma-parse/-/recma-parse-1.0.0.tgz",
       "integrity": "sha1-w1HhYbsKtH2GuSqYqdiR+baBS1I=",
       "license": "MIT",
       "dependencies": {
@@ -6673,7 +6190,6 @@
     },
     "node_modules/recma-stringify": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recma-stringify/-/recma-stringify-1.0.0.tgz",
       "integrity": "sha1-VGMgMGMeDHVGE2/574/ejntE8TA=",
       "license": "MIT",
       "dependencies": {
@@ -6689,7 +6205,6 @@
     },
     "node_modules/regex": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regex/-/regex-6.1.0.tgz",
       "integrity": "sha1-186Y+O4y2nSXwT9mAfyivEpqeAM=",
       "license": "MIT",
       "dependencies": {
@@ -6698,7 +6213,6 @@
     },
     "node_modules/regex-recursion": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha1-oLGXenTIfwczd7k42+36supYKzM=",
       "license": "MIT",
       "dependencies": {
@@ -6707,13 +6221,11 @@
     },
     "node_modules/regex-utilities": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha1-hxY1EqFdzikIzweciWDVFY/0MoA=",
       "license": "MIT"
     },
     "node_modules/rehype": {
       "version": "13.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype/-/rehype-13.0.2.tgz",
       "integrity": "sha1-qws6wmVz17JloAmf7/rUUOTPGVI=",
       "license": "MIT",
       "dependencies": {
@@ -6729,7 +6241,6 @@
     },
     "node_modules/rehype-expressive-code": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-expressive-code/-/rehype-expressive-code-0.44.1.tgz",
       "integrity": "sha1-puKJiFR7LTBppC69ymlOAhhEzmA=",
       "license": "MIT",
       "dependencies": {
@@ -6738,7 +6249,6 @@
     },
     "node_modules/rehype-format": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-format/-/rehype-format-5.0.1.tgz",
       "integrity": "sha1-4lXlm+0MBiFWqvUcFvrVpSGh9cg=",
       "license": "MIT",
       "dependencies": {
@@ -6752,7 +6262,6 @@
     },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-parse/-/rehype-parse-9.0.1.tgz",
       "integrity": "sha1-mZO9oSmsxkxBep02VKe+OLKpTCA=",
       "license": "MIT",
       "dependencies": {
@@ -6767,7 +6276,6 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-raw/-/rehype-raw-7.0.0.tgz",
       "integrity": "sha1-Wdc0j9Xb7zgHu6odRD79LdhezuQ=",
       "license": "MIT",
       "dependencies": {
@@ -6782,7 +6290,6 @@
     },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-recma/-/rehype-recma-1.0.0.tgz",
       "integrity": "sha1-1o72NE0FkWvZbiVADGJhd1QRqnY=",
       "license": "MIT",
       "dependencies": {
@@ -6797,7 +6304,6 @@
     },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
       "integrity": "sha1-LsHrxWxqugeQXTtEcL3w9oTzC3U=",
       "license": "MIT",
       "dependencies": {
@@ -6812,7 +6318,6 @@
     },
     "node_modules/remark-directive": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-directive/-/remark-directive-4.0.0.tgz",
       "integrity": "sha1-TpCYJuBcref4Z4Uy9IFc2THUfo0=",
       "license": "MIT",
       "dependencies": {
@@ -6828,7 +6333,6 @@
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha1-MyJ7KnQ5dnDTV78FwJjq+FE/DWs=",
       "license": "MIT",
       "dependencies": {
@@ -6846,7 +6350,6 @@
     },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-mdx/-/remark-mdx-3.1.1.tgz",
       "integrity": "sha1-BH+XA4vH7Dh667SwpP4jd5mZ2EU=",
       "license": "MIT",
       "dependencies": {
@@ -6860,7 +6363,6 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha1-qmB0P8s36/awaSBOtNowTkDbRaE=",
       "license": "MIT",
       "dependencies": {
@@ -6876,7 +6378,6 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-rehype/-/remark-rehype-11.1.2.tgz",
       "integrity": "sha1-Kt2q3agMqb2aoNp2PnTRYydoOzc=",
       "license": "MIT",
       "dependencies": {
@@ -6893,7 +6394,6 @@
     },
     "node_modules/remark-smartypants": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
       "integrity": "sha1-MrTyC0ZtFrPC9Mx38xAZJw6pems=",
       "license": "MIT",
       "dependencies": {
@@ -6908,7 +6408,6 @@
     },
     "node_modules/remark-stringify": {
       "version": "11.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha1-TFsB3XEcJp3xqq4RdD634udjb9M=",
       "license": "MIT",
       "dependencies": {
@@ -6923,7 +6422,6 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha1-YWs9wsVwVrVYjDHN9LPWTbEzcg8=",
       "license": "MIT",
       "funding": {
@@ -6932,7 +6430,6 @@
     },
     "node_modules/retext": {
       "version": "9.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retext/-/retext-9.0.0.tgz",
       "integrity": "sha1-q1zXKDaJQWewymrnD9z6oWYmf3o=",
       "license": "MIT",
       "dependencies": {
@@ -6948,7 +6445,6 @@
     },
     "node_modules/retext-latin": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retext-latin/-/retext-latin-4.0.0.tgz",
       "integrity": "sha1-0CSYqh/TnxvwDi/1mxOEwF0MfOM=",
       "license": "MIT",
       "dependencies": {
@@ -6963,7 +6459,6 @@
     },
     "node_modules/retext-smartypants": {
       "version": "6.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
       "integrity": "sha1-ToUsKXTPLPolPu7EJ8l+/EO10Vg=",
       "license": "MIT",
       "dependencies": {
@@ -6978,7 +6473,6 @@
     },
     "node_modules/retext-stringify": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retext-stringify/-/retext-stringify-4.0.0.tgz",
       "integrity": "sha1-UB1UQL1NEh41HHxQn4UH3pYR4Vk=",
       "license": "MIT",
       "dependencies": {
@@ -6993,13 +6487,11 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/robust-predicates/-/robust-predicates-3.0.3.tgz",
       "integrity": "sha1-EJkGGzNJ4sWr7GwqsKzUQNJNQGI=",
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.2.3.tgz",
       "integrity": "sha1-EDvcu9V11RJlJ3uLUQ8ICCe2628=",
       "license": "MIT",
       "dependencies": {
@@ -7031,7 +6523,6 @@
     },
     "node_modules/roughjs": {
       "version": "4.6.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/roughjs/-/roughjs-4.6.6.tgz",
       "integrity": "sha1-EFn0ml4MgN7lQaAFsgzDIrIiFYs=",
       "license": "MIT",
       "dependencies": {
@@ -7043,19 +6534,16 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
       "license": "BSD-3-Clause"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "license": "MIT"
     },
     "node_modules/satteri": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/satteri/-/satteri-0.9.5.tgz",
       "integrity": "sha1-J8h+v3YIuxYfTLUQi5YchDjBiLc=",
       "license": "MIT",
       "dependencies": {
@@ -7078,7 +6566,6 @@
     },
     "node_modules/sax": {
       "version": "1.6.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sax/-/sax-1.6.1.tgz",
       "integrity": "sha1-TCPPYIwLaTq1S0tYiOks/pd7mEM=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -7087,7 +6574,6 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "license": "ISC",
       "bin": {
@@ -7099,7 +6585,6 @@
     },
     "node_modules/sharp": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sharp/-/sharp-0.35.3.tgz",
       "integrity": "sha1-Qe0hpGQGvhY+rNC+ezZLQvzyiF8=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7148,7 +6633,6 @@
     },
     "node_modules/shiki": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shiki/-/shiki-4.4.3.tgz",
       "integrity": "sha1-MftBxcgkNXeaC1qbkqOwN3sGHhU=",
       "license": "MIT",
       "dependencies": {
@@ -7167,13 +6651,11 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "license": "MIT"
     },
     "node_modules/sitemap": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sitemap/-/sitemap-9.0.1.tgz",
       "integrity": "sha1-M+mwniF364luBbFtpCGfU5GYQvY=",
       "license": "MIT",
       "dependencies": {
@@ -7192,7 +6674,6 @@
     },
     "node_modules/smol-toml": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/smol-toml/-/smol-toml-1.8.0.tgz",
       "integrity": "sha1-3F4JNoJfH+83vfLFaQgfcJ2KAJ8=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -7204,7 +6685,6 @@
     },
     "node_modules/source-map": {
       "version": "0.7.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha1-o2WKuH5bZCnIofO6AIPUxhyj7wI=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -7213,7 +6693,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -7222,7 +6701,6 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha1-Hs2dI1CjhEVyw/SjErzrAYNIhZ8=",
       "license": "MIT",
       "funding": {
@@ -7232,13 +6710,11 @@
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha1-5J/VhL0cYzYT4BC8c7nbSctQJK0=",
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha1-s7ee9fJ3zErHPK6wI2xbqTmzpPM=",
       "license": "MIT",
       "dependencies": {
@@ -7252,7 +6728,6 @@
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/style-to-js/-/style-to-js-1.1.21.tgz",
       "integrity": "sha1-KQiUEYf4V+eeKOnNeACLmgs+Do0=",
       "license": "MIT",
       "dependencies": {
@@ -7261,7 +6736,6 @@
     },
     "node_modules/style-to-object": {
       "version": "1.0.14",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/style-to-object/-/style-to-object-1.0.14.tgz",
       "integrity": "sha1-HSLw5yZruMbYyuXK9OxPAF4I9hE=",
       "license": "MIT",
       "dependencies": {
@@ -7270,13 +6744,11 @@
     },
     "node_modules/stylis": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha1-xYRsk0X0v8Ub0MvXyjWgdE9IWl0=",
       "license": "MIT"
     },
     "node_modules/svgo": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/svgo/-/svgo-4.0.2.tgz",
       "integrity": "sha1-piJG8KnWccAxTQTzzBX3ixvQZn8=",
       "license": "MIT",
       "dependencies": {
@@ -7301,7 +6773,6 @@
     },
     "node_modules/svgo/node_modules/commander": {
       "version": "11.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-11.1.0.tgz",
       "integrity": "sha1-Yv3OdgBqaOXBqzMU3JLoAOuD2QY=",
       "license": "MIT",
       "engines": {
@@ -7310,13 +6781,11 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha1-EicVSUkToYBRZqr3yTRnkz7qJsQ=",
       "license": "MIT"
     },
     "node_modules/tinyclip": {
       "version": "0.1.15",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyclip/-/tinyclip-0.1.15.tgz",
       "integrity": "sha1-2zXqor1f5iez7y6jjYsEB/K8Le8=",
       "license": "MIT",
       "engines": {
@@ -7325,7 +6794,6 @@
     },
     "node_modules/tinyexec": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyexec/-/tinyexec-1.3.0.tgz",
       "integrity": "sha1-qswdux1Ok+atjdZJROCfmtFHpHQ=",
       "license": "MIT",
       "engines": {
@@ -7334,7 +6802,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "license": "MIT",
       "dependencies": {
@@ -7350,7 +6817,6 @@
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha1-2ALjMqB9+GHEiALAQyEBexvYczg=",
       "license": "MIT",
       "funding": {
@@ -7360,7 +6826,6 @@
     },
     "node_modules/trough": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/trough/-/trough-2.2.0.tgz",
       "integrity": "sha1-lKYL1r03XBUsHfkRpLEdWwJW9Q8=",
       "license": "MIT",
       "funding": {
@@ -7370,7 +6835,6 @@
     },
     "node_modules/ts-dedent": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-dedent/-/ts-dedent-2.3.0.tgz",
       "integrity": "sha1-j6w2x5ArVBwVSsE6J6xGeZevEfg=",
       "license": "MIT",
       "engines": {
@@ -7379,38 +6843,32 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD",
       "optional": true
     },
     "node_modules/ufo": {
       "version": "1.6.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha1-eo+4dfzGOC0sfQs2knOLBQCpJGc=",
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ultrahtml/-/ultrahtml-1.7.0.tgz",
       "integrity": "sha1-jn1ZfjOKSB6oKFKpul6AIcVK7RA=",
       "license": "MIT"
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha1-4SiNYJIm8tAtjWnuhh+iDYNI7ys=",
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha1-KTV6iee3ykrvO/D9P9DNc4hCKek=",
       "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unified/-/unified-11.0.5.tgz",
       "integrity": "sha1-9mZ3YQpcCp7pDKsrjU1mA3Am2eE=",
       "license": "MIT",
       "dependencies": {
@@ -7429,7 +6887,6 @@
     },
     "node_modules/unifont": {
       "version": "0.7.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unifont/-/unifont-0.7.4.tgz",
       "integrity": "sha1-YravaPS2Ato0n8ENySUl/5O/8yk=",
       "license": "MIT",
       "dependencies": {
@@ -7440,7 +6897,6 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
       "integrity": "sha1-P8zBsIa1bzTIt5jh/5C1xURo6JY=",
       "license": "MIT",
       "dependencies": {
@@ -7454,7 +6910,6 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha1-0KP4by3Q23rNfYwkeAgLXGf5xqk=",
       "license": "MIT",
       "dependencies": {
@@ -7467,7 +6922,6 @@
     },
     "node_modules/unist-util-modify-children": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
       "integrity": "sha1-mB1jCOiHsAXR9JGBHTy8wlSzFek=",
       "license": "MIT",
       "dependencies": {
@@ -7481,7 +6935,6 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha1-Z48gq1yhIHqX1+qKOINzyc+Ja+Q=",
       "license": "MIT",
       "dependencies": {
@@ -7494,7 +6947,6 @@
     },
     "node_modules/unist-util-position-from-estree": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
       "integrity": "sha1-2U2k31llKdH6o95QYgLwyaI/IgA=",
       "license": "MIT",
       "dependencies": {
@@ -7507,7 +6959,6 @@
     },
     "node_modules/unist-util-remove-position": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
       "integrity": "sha1-/qaKJWWECclGBAi8a0mRuWW1IWM=",
       "license": "MIT",
       "dependencies": {
@@ -7521,7 +6972,6 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha1-RJxuIaiA4IVb9aq63rOnQDFKusI=",
       "license": "MIT",
       "dependencies": {
@@ -7534,7 +6984,6 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha1-mioosKp2oV4NpwoIpYY6LwYOJGg=",
       "license": "MIT",
       "dependencies": {
@@ -7549,7 +6998,6 @@
     },
     "node_modules/unist-util-visit-children": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
       "integrity": "sha1-S87Rmbcdfzw5dUPqbMOeen833H4=",
       "license": "MIT",
       "dependencies": {
@@ -7562,7 +7010,6 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha1-d333+5hlLOFrS3zZmdChpA76OgI=",
       "license": "MIT",
       "dependencies": {
@@ -7576,7 +7023,6 @@
     },
     "node_modules/unstorage": {
       "version": "1.17.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unstorage/-/unstorage-1.17.5.tgz",
       "integrity": "sha1-52yC/cHSwEyw4sCh3giqCLIlP1E=",
       "license": "MIT",
       "dependencies": {
@@ -7672,7 +7118,6 @@
     },
     "node_modules/url-extras": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/url-extras/-/url-extras-0.1.0.tgz",
       "integrity": "sha1-kFxfPR0tYoTZcxyHYlu/pwL9ra0=",
       "license": "MIT",
       "engines": {
@@ -7684,13 +7129,11 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uuid/-/uuid-14.0.1.tgz",
       "integrity": "sha1-ill1s+A4kCv9FpoQtSAvXsDPP68=",
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -7703,7 +7146,6 @@
     },
     "node_modules/vfile": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha1-NlKrHEllMYUr9VprrFevmB68OKs=",
       "license": "MIT",
       "dependencies": {
@@ -7717,7 +7159,6 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile-location/-/vfile-location-5.0.3.tgz",
       "integrity": "sha1-y56s0g8rZCbRlFHg6vo9CoRiJcM=",
       "license": "MIT",
       "dependencies": {
@@ -7731,7 +7172,6 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha1-h7RN3de3DwZBwuPtCGS6c+LqjfQ=",
       "license": "MIT",
       "dependencies": {
@@ -7745,7 +7185,6 @@
     },
     "node_modules/vite": {
       "version": "8.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.2.1.tgz",
       "integrity": "sha1-b8jYu4Q71SNTCR+sl44ZTU3lsx0=",
       "license": "MIT",
       "dependencies": {
@@ -7822,7 +7261,6 @@
     },
     "node_modules/vitefu": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitefu/-/vitefu-1.1.3.tgz",
       "integrity": "sha1-WbmIWxwgCFYxnX6c6w6ZoGVDAAk=",
       "license": "MIT",
       "workspaces": [
@@ -7841,7 +7279,6 @@
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha1-EBD/fGUOzLJZLOvur5obJT/UBpI=",
       "license": "MIT",
       "funding": {
@@ -7851,13 +7288,11 @@
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha1-/+fwuYIgpK+sFx4/ubbR+HcfAV4=",
       "license": "MIT"
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha1-h7gglAUbBWdxc0bs0A/RSASzV8g=",
       "license": "ISC",
       "engines": {
@@ -7866,7 +7301,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yocto-queue/-/yocto-queue-1.2.2.tgz",
       "integrity": "sha1-PgnJXT8aqJpYwRTJkiPt9jkVLAA=",
       "license": "MIT",
       "engines": {
@@ -7878,7 +7312,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "license": "MIT",
       "funding": {
@@ -7887,7 +7320,6 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha1-yCfUsKy3b8PmhaTG7CkC1RBw6dc=",
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
## 概要

- プロジェクトルートの `.npmrc` に `omit-lockfile-registry-resolved=true` を追加
- npm 10.9.4 で `package-lock.json` を再生成し、Azure Artifacts の `resolved` URL 568 件を削除
- 依存関係、integrity、lockfileVersion、その他のメタデータに変更がないことを確認

## 検証

- `npm config get omit-lockfile-registry-resolved`: `true`
- `resolved` フィールド: 0 件
- `pkgs.visualstudio.com` URL: 0 件
- 再生成後の `package-lock.json` SHA-256 が再実行前後で一致
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run build`

fixes #37